### PR TITLE
Fix #132 (extra history entries from mode switch)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -292,14 +292,16 @@ export default class KanbanPlugin extends Plugin {
     await leaf.setViewState({
       type: "markdown",
       state: leaf.view.getState(),
-    });
+      popstate: true,
+    } as ViewState);
   }
 
   async setKanbanView(leaf: WorkspaceLeaf) {
     await leaf.setViewState({
       type: kanbanViewType,
       state: leaf.view.getState(),
-    });
+      popstate: true,
+    } as ViewState);
   }
 
   async newKanban(folder?: TFolder) {


### PR DESCRIPTION
Adding `popstate` keeps Obsidian from creating new history entries for a different view on the same file.