### PR TITLE
Create cards by dropping or pasting links, text, or file(s) into "Add a card" area

### DIFF
--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import {MarkdownSourceView, parseLinktext, TFile} from "obsidian";
 import useOnclickOutside from "react-cool-onclickoutside";
 
 import { Item } from "../types";
@@ -15,7 +16,7 @@ interface ItemFormProps {
 export function ItemForm({ addItems }: ItemFormProps) {
   const [isInputVisible, setIsInputVisible] = React.useState(false);
   const [itemTitle, setItemTitle] = React.useState("");
-  const { view } = React.useContext(ObsidianContext);
+  const { view, filePath } = React.useContext(ObsidianContext);
 
   const clickOutsideRef = useOnclickOutside(
     () => {
@@ -66,6 +67,29 @@ export function ItemForm({ addItems }: ItemFormProps) {
     onEscape: clear,
   });
 
+  function linkTo(f: TFile, subpath?: string) {
+    // Generate a link relative to this Kanban board, respecting user link type preferences
+    return view.app.fileManager.generateMarkdownLink(f, filePath, subpath);
+  }
+
+  function getMarkdown(transfer: DataTransfer ) {
+    // crude hack to use Obsidian's html-to-markdown converter (replace when Obsidian exposes it in API):
+    return (MarkdownSourceView.prototype as any).handleDataTransfer.call({app: view.app}, transfer)
+  }
+
+  function fixBulletsAndLInks(text: string) {
+    // Internal links from e.g. dataview plugin incorrectly begin with `app://obsidian.md/`, and
+    // we also want to remove bullet points and task markers from text and markdown
+    return text.replace(/^\s*[-+*]\s+(\[.]\s+)?/, "").trim().replace(/^\[(.*)\]\(app:\/\/obsidian.md\/(.*)\)$/, "[$1]($2)");
+  }
+
+  function dropAction(transfer: DataTransfer) {
+    // Return a 'copy' or 'link' action according to the content types, or undefined if no recognized type
+    if (transfer.types.includes('text/uri-list')) return 'link';
+    if (['file', 'files', 'link'].includes((view.app as any).dragManager.draggable?.type)) return 'link';
+    if (transfer.types.includes('text/html') || transfer.types.includes('text/plain')) return 'copy';
+  }
+
   if (isInputVisible) {
     return (
       <div ref={clickOutsideRef}>
@@ -79,6 +103,40 @@ export function ItemForm({ addItems }: ItemFormProps) {
               onChange={(e) =>
                 setItemTitle(e.target.value.replace(/[\r\n]+/g, " "))
               }
+              onDragOver={e => {
+                const action = dropAction(e.dataTransfer);
+                if (action) {
+                  e.dataTransfer.dropEffect = action;
+                  e.preventDefault();
+                  return false;
+                }
+              }}
+              onDragLeave={() => { if (!itemTitle) setIsInputVisible(false); }}
+              onDrop={e => {
+                const draggable = (view.app as any).dragManager.draggable;
+                const html  = e.dataTransfer.getData("text/html");
+                const plain = e.dataTransfer.getData("text/plain");
+                const uris  = e.dataTransfer.getData("text/uri-list");
+
+                if (draggable?.type === "file") {
+                  addItemsFromStrings([linkTo(draggable.file)]);
+                } else if (draggable?.type === "files") {
+                  addItemsFromStrings(draggable.files.map(linkTo));
+                } else if (draggable?.type === "link") {
+                  let link = draggable.file ? linkTo(draggable.file, parseLinktext(draggable.linktext).subpath) : `[[${draggable.linktext}]]`;
+                  let alias = new DOMParser().parseFromString(html, "text/html").documentElement.textContent;  // Get raw text
+                  link = link.replace(/]]$/, `|${alias}]]`).replace(/^\[[^\]].+]\(/, `[${alias}](`);
+                  addItemsFromStrings([link]);
+                } else {
+                  // shift key to force plain text, the same way Obsidian does it
+                  const text = e.shiftKey ? (plain||html) : getMarkdown(e.dataTransfer);
+
+                  // Split lines and strip leading bullets/task indicators
+                  const lines: string[] = (text || html || uris || plain || "").split(/\r\n?|\n/).map(fixBulletsAndLInks);
+                  addItemsFromStrings(lines.filter(line => line));
+                }
+                if (!itemTitle) setIsInputVisible(false);
+              }}
               {...autocompleteProps}
             />
           </div>
@@ -100,6 +158,7 @@ export function ItemForm({ addItems }: ItemFormProps) {
       <button
         className={c("new-item-button")}
         onClick={() => setIsInputVisible(true)}
+        onDragOver={e => { if (dropAction(e.dataTransfer)) setIsInputVisible(true); }}
       >
         <span className={c("item-button-plus")}>+</span> {t("Add a card")}
       </button>

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -9,10 +9,10 @@ import { processTitle } from "src/parser";
 import { t } from "src/lang/helpers";
 
 interface ItemFormProps {
-  addItem: (item: Item) => void;
+  addItems: (items: Item[]) => void;
 }
 
-export function ItemForm({ addItem }: ItemFormProps) {
+export function ItemForm({ addItems }: ItemFormProps) {
   const [isInputVisible, setIsInputVisible] = React.useState(false);
   const [itemTitle, setItemTitle] = React.useState("");
   const { view } = React.useContext(ObsidianContext);
@@ -33,9 +33,16 @@ export function ItemForm({ addItem }: ItemFormProps) {
 
   const createItem = () => {
     const title = itemTitle.trim();
-    const processed = processTitle(title, view);
 
     if (title) {
+      addItemsFromStrings([title]);
+      setItemTitle("");
+    }
+  };
+
+  const addItemsFromStrings = (titles: string[]) => {
+    addItems(titles.map(title => {
+      const processed = processTitle(title, view);
       const newItem: Item = {
         id: generateInstanceId(),
         title: processed.title,
@@ -49,10 +56,8 @@ export function ItemForm({ addItem }: ItemFormProps) {
           file: processed.file,
         },
       };
-
-      addItem(newItem);
-      setItemTitle("");
-    }
+      return newItem;
+    }));
   };
 
   const autocompleteProps = useAutocompleteInputProps({

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -114,15 +114,15 @@ function getBoardModifiers({
   };
 
   return {
-    addItemToLane: (laneIndex: number, item: Item) => {
-      view.app.workspace.trigger("kanban:card-added", view.file, item);
+    addItemsToLane: (laneIndex: number, items: Item[]) => {
+      items.forEach(item => view.app.workspace.trigger("kanban:card-added", view.file, item));
 
       setBoardData(
         update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
-                $push: [item],
+                $push: items,
               },
             },
           },

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -127,17 +127,19 @@ export function draggableLaneFactory({
           shouldMarkItemsComplete={shouldMarkItemsComplete}
         />
         <ItemForm
-          addItem={(item: Item) => {
-            boardModifiers.addItemToLane(
+          addItems={(items: Item[]) => {
+            boardModifiers.addItemsToLane(
               rubric.source.index,
-              update(item, {
-                data: {
-                  isComplete: {
-                    // Mark the item complete if we're moving into a completed lane
-                    $set: !!lane.data.shouldMarkItemsComplete,
+              items.map(item =>
+                update(item, {
+                  data: {
+                    isComplete: {
+                      // Mark the item complete if we're moving into a completed lane
+                      $set: !!lane.data.shouldMarkItemsComplete,
+                    },
                   },
-                },
-              })
+                })
+              )
             );
           }}
         />

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -40,7 +40,7 @@ export interface Board {
 }
 
 export interface BoardModifiers {
-  addItemToLane: (laneIndex: number, item: Item) => void;
+  addItemsToLane: (laneIndex: number, items: Item[]) => void;
   addLane: (lane: Lane) => void;
   archiveItem: (laneIndex: number, itemIndex: number, item: Item) => void;
   archiveLane: (laneIndex: number) => void;


### PR DESCRIPTION
Drop or paste any of the following into the "+ Add a card" area of a lane, to add one or more cards:

* File(s) (single or multi) from the explorer pane
* Files from plugins whose views support it (stars, recent-files, pane-relief history, backlinks, etc.)
* Internal and external links from any preview (including page previews and dataview-generated links)
* HTML, plain text, and URLs from anywhere in Obsidian and from other apps.

HTML is converted to markdown, unless you've disabled that in Obsidian's config, or if you hold shift while dropping.  Every line, paragraph, file, or link becomes a separate card.  (Or in the case of pasting, if there's only one line of text, it's pasted in the textarea as usual.)