### PR TITLE
Implement #31: Drag and drop between boards

### DIFF
--- a/src/DataBridge.ts
+++ b/src/DataBridge.ts
@@ -11,6 +11,7 @@ export class DataBridge {
   // When data has been set in obsidian land
   onExternalSet(fn: DataHandler) {
     this.onExternalSetHandlers.push(fn);
+    return () => this.onExternalSetHandlers.remove(fn);
   }
 
   // When data has been set in react land

--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -1,0 +1,100 @@
+import { App, Notice } from "obsidian";
+import React from "react";
+import { DragDropContext, DropResult } from "react-beautiful-dnd";
+import { BoardMutator, deleteItem, deleteLane, insertItem, insertLane, moveItem, swapItems, swapLanes } from "./components/helpers";
+import { Board, Item } from "./components/types";
+import { KanbanView, kanbanViewType } from "./KanbanView";
+
+export function DragDropApp(app: App) {
+  const portals = allViews().map(view => view.getPortal());
+  if (portals.length) return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      {...portals}
+    </DragDropContext>
+  );
+
+  function allViews(): KanbanView[] {
+    return app.workspace.getLeavesOfType(kanbanViewType).map(leaf => leaf.view as KanbanView);
+  }
+
+  function onDragEnd(dropResult: DropResult) {
+    // Bail out early if we're not dropping anywhere
+    const {source, destination} = dropResult;
+    if (!destination) return;
+
+    const srcLoc = boardContextFor(dropResult, source.droppableId);
+    const dstLoc = boardContextFor(dropResult, destination.droppableId);
+    if (!srcLoc || !dstLoc) return new Notice("Invalid source or destination for drop");
+
+    let srcMutator : BoardMutator;
+    let dstMutator : BoardMutator;
+    let item: Item;
+
+    if (srcLoc.file !== dstLoc.file) {
+      // Two different files
+      if (dropResult.type === "LANE") {
+        srcMutator = deleteLane(source.index);
+        dstMutator = insertLane(destination.index, srcLoc.getData().lanes[source.index]);
+      } else {
+        item = srcLoc.getData().lanes[srcLoc.laneIndex].items[source.index];
+        srcMutator = deleteItem(srcLoc.laneIndex, source.index);
+        dstMutator = insertItem(dstLoc.laneIndex, destination.index, item);
+      }
+    } else {
+      if (srcLoc.view !== dstLoc.view) {
+        // drag between two views on the same file, might need to fudge position (due to the copy of src in dst)
+        if (destination.index > source.index) --destination.index;
+      }
+      // Nominal case: same file, same view
+      if (dropResult.type === "LANE") {
+        // Swap lanes
+        srcMutator = dstMutator = swapLanes(source.index, destination.index);
+      } else if (srcLoc.laneIndex === dstLoc.laneIndex) {
+        // Swap items within a lane
+        srcMutator = dstMutator = swapItems(srcLoc.laneIndex, source.index, destination.index);
+      } else {
+        // Move item from one lane to another
+        srcMutator = dstMutator = moveItem(srcLoc.laneIndex, source.index, dstLoc.laneIndex, destination.index);
+        const lanes = srcLoc.getData().lanes;
+        item = lanes[srcLoc.laneIndex].items[source.index];
+        app.workspace.trigger(
+          "kanban:card-moved", srcLoc.file, lanes[srcLoc.laneIndex], lanes[dstLoc.laneIndex], item
+        );
+      }
+    }
+
+    // Apply changes at destination view first, so UI changes immediately
+    //   (but only if there's more than one view involved)
+    if (srcLoc.view !== dstLoc.view && dstMutator) {
+      // if it's the same file+change, just update the display; the change will be saved
+      //   when it's applied to the source, below.
+      dstLoc.mutate(dstMutator, srcMutator === dstMutator && srcLoc.file === dstLoc.file);
+    }
+
+    // Apply changes to source (if any), and always save it
+    if (srcMutator) srcLoc.mutate(srcMutator);
+  }
+
+  function boardContextFor(dropResult: DropResult, id: string) {
+    for(const view of allViews()) {
+      if (dropResult.type === "LANE" && (view.leaf as any).id === id) return boardContext(view);
+      const index = view.dataBridge.data.lanes.findIndex(lane => lane.id === id);
+      if (index >= 0) return boardContext(view, index);
+    }
+  }
+
+  function boardContext(view: KanbanView, laneIndex?: number) {
+    return {
+      view, laneIndex, file: view.file,
+      mutate(mutator: BoardMutator, preview = false) {
+        const bridge = view.dataBridge;
+        const board = mutator(bridge.getData());
+        // Save the change unless we're previewing
+        if (!preview) bridge.setInternal(board);
+        // And always Update the display
+        bridge.setExternal(board);
+      },
+      getData(): Board { return view.dataBridge.getData(); }
+    }
+  }
+}

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -34,6 +34,7 @@ export class KanbanView extends TextFileView implements HoverParent {
   dataBridge: DataBridge;
   hoverPopover: HoverPopover | null;
   parseError: string;
+  closed: boolean = false;
 
   getViewType() {
     return kanbanViewType;
@@ -54,6 +55,8 @@ export class KanbanView extends TextFileView implements HoverParent {
   }
 
   async onClose() {
+    // Remove draggables from render, as the DOM has already detached
+    this.closed = true;
     this.plugin.refreshViews();
   }
 
@@ -255,7 +258,7 @@ export class KanbanView extends TextFileView implements HoverParent {
   }
 
   getPortal() {
-    return ReactDOM.createPortal(
+    if (!this.closed) return ReactDOM.createPortal(
       <HandleErrors errorMessage={this.parseError}>
         <Kanban
           dataBridge={this.dataBridge}

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -50,7 +50,6 @@ export class KanbanView extends TextFileView implements HoverParent {
   constructor(leaf: WorkspaceLeaf, plugin: KanbanPlugin) {
     super(leaf);
     this.plugin = plugin;
-    this.parseError = ""
     this.clear();
   }
 
@@ -143,6 +142,7 @@ export class KanbanView extends TextFileView implements HoverParent {
   }
 
   clear() {
+    this.parseError = ""
     this.dataBridge = new DataBridge();
     // When the board has been updated by react
     this.dataBridge.onInternalSet((data) => {
@@ -179,8 +179,9 @@ export class KanbanView extends TextFileView implements HoverParent {
         };
     } catch (e) {
       console.error(e);
-      this.parseError = "Error parsing document: " + e;
+      // Force a new databridge to ensure Kanban re-renders when the error goes away
       this.clear()
+      this.parseError = "Error parsing document: " + e;
     }
 
     // Tell react we have a new board

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -266,7 +266,8 @@ export class KanbanView extends TextFileView implements HoverParent {
           view={this}
         />
       </HandleErrors>,
-      this.contentEl
+      this.contentEl,
+      (this.leaf as any).id as string   // ensure React doesn't recreate when list is re-ordered
     );
   }
 }

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -325,11 +325,7 @@ export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
 
   const maxArchiveLength = view.getSetting("max-archive-size");
 
-  React.useEffect(() => {
-    dataBridge.onExternalSet((data) => {
-      setBoardData(data);
-    });
-  }, []);
+  React.useEffect(() => dataBridge.onExternalSet(setBoardData));
 
   React.useEffect(() => {
     if (boardData !== null) {

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -13,10 +13,6 @@ import { Board, BoardModifiers, Item, Lane } from "./types";
 import {
   c,
   baseClassName,
-  BoardDropMutationParams,
-  swapLanes,
-  swapItems,
-  moveItem,
   getDefaultDateFormat,
   getDefaultTimeFormat,
 } from "./helpers";
@@ -38,46 +34,6 @@ interface BoardStateProps {
   view: KanbanView;
   boardData: Board;
   setBoardData: React.Dispatch<Board>;
-}
-
-export function getBoardDragHandler({
-  view,
-  boardData,
-  setBoardData,
-}: BoardStateProps) {
-  return (dropResult: DropResult) => {
-    const { source, destination } = dropResult;
-
-    // Bail out early if we're not dropping anywhere
-    if (
-      !destination ||
-      (source.droppableId === destination.droppableId &&
-        source.index === destination.index)
-    ) {
-      return;
-    }
-
-    const mutationParams: BoardDropMutationParams = {
-      view,
-      boardData,
-      dropResult,
-    };
-
-    // Swap lanes
-    if (dropResult.type === "LANE") {
-      setBoardData(swapLanes(mutationParams));
-      return;
-    }
-
-    // Swap items within a lane
-    if (source.droppableId === destination.droppableId) {
-      setBoardData(swapItems(mutationParams));
-      return;
-    }
-
-    // Move item from one lane to another
-    setBoardData(moveItem(mutationParams));
-  };
 }
 
 function getBoardModifiers({
@@ -362,14 +318,6 @@ export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
     return getBoardModifiers({ view, boardData, setBoardData });
   }, [view, boardData, setBoardData]);
 
-  const onDragEnd = React.useMemo(() => {
-    return getBoardDragHandler({
-      view,
-      boardData,
-      setBoardData,
-    });
-  }, [view, boardData, setBoardData]);
-
   if (boardData === null) return null;
 
   const renderLane = draggableLaneFactory({
@@ -500,9 +448,8 @@ export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
             onMouseOver={onMouseOver}
             onClick={onClick}
           >
-            <DragDropContext onDragEnd={onDragEnd}>
               <Droppable
-                droppableId="board"
+                droppableId={(view.leaf as any).id}
                 type="LANE"
                 direction="horizontal"
                 ignoreContainerClipping={false}
@@ -510,7 +457,6 @@ export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
               >
                 {renderLanes}
               </Droppable>
-            </DragDropContext>
           </div>
         </SearchContext.Provider>
       </KanbanContext.Provider>

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -47,7 +47,7 @@ function LaneItems({
         {items.map((item, i) => {
           return (
             <GhostItem
-              item={item}
+              item={item} key={item.id}
               shouldMarkItemsComplete={shouldMarkItemsComplete}
             />
           );

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,10 @@ import {
 import { around } from "monkey-around";
 
 import { kanbanIcon, KanbanView, kanbanViewType } from "./KanbanView";
+import { DragDropApp } from "./DragDropApp";
 import { frontMatterKey } from "./parser";
 import { KanbanSettings, KanbanSettingsTab } from "./Settings";
+import ReactDOM from "react-dom";
 
 // import { KanbanEmbed } from "./KanbanEmbed";
 
@@ -27,6 +29,7 @@ export default class KanbanPlugin extends Plugin {
   kanbanFileModes: { [file: string]: string } = {};
   dbTimers: { [id: string]: number } = {};
   hasSet: { [id: string]: boolean } = {};
+  appEl: HTMLDivElement;
 
   async onload() {
     const self = this;
@@ -297,6 +300,13 @@ export default class KanbanPlugin extends Plugin {
     );
   }
 
+  refreshViews() {
+    ReactDOM.render(
+      DragDropApp(this.app),
+      this.appEl ?? (this.appEl = document.body.createDiv())
+    );
+  }
+
   async setMarkdownView(leaf: WorkspaceLeaf) {
     await leaf.setViewState({
       type: "markdown",
@@ -358,6 +368,11 @@ export default class KanbanPlugin extends Plugin {
 
     // @ts-ignore
     this.app.workspace.unregisterHoverLinkSource(frontMatterKey);
+    if (this.appEl) {
+      this.refreshViews();
+      ReactDOM.unmountComponentAtNode(this.appEl);
+      this.appEl.detach();
+    }
   }
 
   async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,6 +178,7 @@ export default class KanbanPlugin extends Plugin {
     });
 
     this.app.workspace.onLayoutReady(() => {
+      this.refreshViews();
       this.registerEvent(this.app.workspace.on("layout-change", this.refreshViews, this));
       this.register(
         around((this.app as any).commands.commands["editor:open-search"], {

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,6 +178,7 @@ export default class KanbanPlugin extends Plugin {
     });
 
     this.app.workspace.onLayoutReady(() => {
+      this.registerEvent(this.app.workspace.on("layout-change", this.refreshViews, this));
       this.register(
         around((this.app as any).commands.commands["editor:open-search"], {
           checkCallback(next) {


### PR DESCRIPTION
Cards and lanes can be dragged between board views.  (Note that dragging between boards can break links, depending on your Obsidian link settings and whether you have notes with the same name in different locations.)

This is a significant re-organization and should probably be tested more thoroughly, as I only use a fraction of the plugin's features and might not notice if I broke something.