### PR TITLE
Add tag-specific classes.

### DIFF
--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -53,6 +53,10 @@ function getClassModifiers(item: Item) {
     classModifiers.push("is-complete");
   }
 
+  for (let tag of item.metadata.tags) {
+    classModifiers.push(`has-tag-${tag.replace('#', '')}`);
+  }
+
   return classModifiers;
 }
 


### PR DESCRIPTION
This PR adds CSS classes `has-tag-[tagname without # symbol]` to each card. This can be useful for styling cards and customise display to address use cases such as snoozing cards (cf. #138).