### PR TITLE
Misc fixes for file/state updating and refreshing

### DIFF
--- a/src/DataBridge.ts
+++ b/src/DataBridge.ts
@@ -1,32 +1,50 @@
-import { Board } from "./components/types";
+import { useState, useEffect, useMemo } from "react";
 
-export type DataHandler = (data: Board) => void;
+export type DataHandler<T> = (data: T) => void;
 
-export class DataBridge {
-  data: Board | null;
+export class DataBridge<T> {
 
-  onExternalSetHandlers: Array<DataHandler> = [];
-  onInternalSetHandlers: Array<DataHandler> = [];
+  constructor(public data?: T) {}
+
+  // A two-way link version of useState
+  useState(): [T, DataHandler<T>] {
+    // The actual state used on the react end
+    const [state, setState] = useState(this.getData());
+
+    // Which is updated whenever the outside changes
+    useEffect(() => this.onExternalSet(setState));
+
+    // And we return a setter that updates the outside and inside
+    const updateState = useMemo(() => (state: T) => {
+      this.setInternal(state);
+      setState(state);
+    }, [this, setState])
+
+    return [state, updateState];
+  }
+
+  onExternalSetHandlers: Array<DataHandler<T>> = [];
+  onInternalSetHandlers: Array<DataHandler<T>> = [];
 
   // When data has been set in obsidian land
-  onExternalSet(fn: DataHandler) {
+  onExternalSet(fn: DataHandler<T>) {
     this.onExternalSetHandlers.push(fn);
     return () => this.onExternalSetHandlers.remove(fn);
   }
 
   // When data has been set in react land
-  onInternalSet(fn: DataHandler) {
+  onInternalSet(fn: DataHandler<T>) {
     this.onInternalSetHandlers.push(fn);
   }
 
   // Set data from obsidian land
-  setExternal(data: Board) {
+  setExternal(data: T) {
     this.data = data;
     this.onExternalSetHandlers.forEach((fn) => fn(data));
   }
 
   // Set data from react land
-  setInternal(data: Board) {
+  setInternal(data: T) {
     this.data = data;
     this.onInternalSetHandlers.forEach((fn) => fn(data));
   }

--- a/src/DataBridge.ts
+++ b/src/DataBridge.ts
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 export type DataHandler<T> = (data: T) => void;
+export type Reducer<T> = ((old: T) => T)
 
 export class DataBridge<T> {
 
@@ -15,9 +16,15 @@ export class DataBridge<T> {
     useEffect(() => this.onExternalSet(setState), [this]);
 
     // And we return a setter that updates the outside and inside
-    const updateState = useMemo(() => (state: T) => {
-      this.setInternal(state);
-      setState(state);
+    const updateState = useCallback((state: T|Reducer<T>) => {
+      if (typeof state === "function") {
+        // Reducer: capture the result of the change
+        setState((oldState: T) => state = (state as Reducer<T>)(oldState));
+      } else {
+        // Value: just pass it on
+        setState(state);
+      }
+      this.setInternal(state as T);
     }, [this, setState])
 
     return [state, updateState];

--- a/src/DataBridge.ts
+++ b/src/DataBridge.ts
@@ -12,7 +12,7 @@ export class DataBridge<T> {
     const [state, setState] = useState(this.getData());
 
     // Which is updated whenever the outside changes
-    useEffect(() => this.onExternalSet(setState));
+    useEffect(() => this.onExternalSet(setState), [this]);
 
     // And we return a setter that updates the outside and inside
     const updateState = useMemo(() => (state: T) => {
@@ -35,6 +35,7 @@ export class DataBridge<T> {
   // When data has been set in react land
   onInternalSet(fn: DataHandler<T>) {
     this.onInternalSetHandlers.push(fn);
+    return () => this.onExternalSetHandlers.remove(fn);
   }
 
   // Set data from obsidian land

--- a/src/DataBridge.ts
+++ b/src/DataBridge.ts
@@ -42,7 +42,7 @@ export class DataBridge<T> {
   // When data has been set in react land
   onInternalSet(fn: DataHandler<T>) {
     this.onInternalSetHandlers.push(fn);
-    return () => this.onExternalSetHandlers.remove(fn);
+    return () => this.onInternalSetHandlers.remove(fn);
   }
 
   // Set data from obsidian land

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -29,7 +29,7 @@ export const kanbanIcon = "blocks";
 
 export class KanbanView extends TextFileView implements HoverParent {
   plugin: KanbanPlugin;
-  dataBridge: DataBridge;
+  dataBridge: DataBridge<Board>;
   hoverPopover: HoverPopover | null;
   parseError: string;
   closed: boolean = false;

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -172,7 +172,7 @@ export class KanbanView extends TextFileView implements HoverParent {
 
   async onLoadFile(file: TFile) {
     try {
-      return super.onLoadFile(file);
+      return await super.onLoadFile(file);
     }
     catch(e) {
       // Update to display details of the problem

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -21,7 +21,6 @@ import { Icon } from "./Icon/Icon";
 
 interface KanbanProps {
   dataBridge: DataBridge<Board>;
-  filePath?: string;
   view: KanbanView;
 }
 
@@ -273,7 +272,10 @@ function getBoardModifiers({
   };
 }
 
-export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
+export const Kanban = ({view, dataBridge }: KanbanProps) => {
+
+  const filePath = view.file?.path;
+
   const [boardData, setBoardData] = dataBridge.useState();
 
   const [searchQuery, setSearchQuery] = React.useState<string>("");
@@ -444,7 +446,7 @@ export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
             onClick={onClick}
           >
             <Droppable
-              droppableId={(view.leaf as any).id}
+              droppableId={view.id}
               type="LANE"
               direction="horizontal"
               ignoreContainerClipping={false}

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -20,7 +20,7 @@ import { t } from "src/lang/helpers";
 import { Icon } from "./Icon/Icon";
 
 interface KanbanProps {
-  dataBridge: DataBridge;
+  dataBridge: DataBridge<Board>;
   filePath?: string;
   view: KanbanView;
 }
@@ -274,22 +274,15 @@ function getBoardModifiers({
 }
 
 export const Kanban = ({ filePath, view, dataBridge }: KanbanProps) => {
-  const [boardData, setBoardData] = React.useState<Board | null>(
-    dataBridge.data
-  );
+  const [boardData, setBoardData] = dataBridge.useState();
 
   const [searchQuery, setSearchQuery] = React.useState<string>("");
   const searchRef = React.useRef<HTMLInputElement>();
 
   const maxArchiveLength = view.getSetting("max-archive-size");
 
-  React.useEffect(() => dataBridge.onExternalSet(setBoardData));
-
-  React.useEffect(() => {
-    if (boardData !== null) {
-      dataBridge.setInternal(boardData);
-    }
-  }, [boardData]);
+  // Don't render anything if there's no board
+  if (!boardData) return <div/>;
 
   React.useEffect(() => {
     if (boardData.isSearching) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,7 @@ export default class KanbanPlugin extends Plugin {
     // });
 
     // Monkey patch WorkspaceLeaf to open Kanbans with KanbanView by default
+    const plugin: any = this;
     this.register(
       around(WorkspaceLeaf.prototype, {
         // Kanbans can be viewed as markdown or kanban, and we keep track of the mode
@@ -156,6 +157,8 @@ export default class KanbanPlugin extends Plugin {
         setViewState(next) {
           return function (state: ViewState, ...rest: any[]) {
             if (
+              // Don't force kanban mode during shutdown
+              plugin._loaded &&
               // If we have a markdown file
               state.type === "markdown" &&
               state.state?.file &&
@@ -380,6 +383,9 @@ export default class KanbanPlugin extends Plugin {
   }
 
   onunload() {
+    // Unmount views from the display first, so we don't get intermediate render thrashing
+    this.views.setExternal(new Map)
+
     const kanbanLeaves = this.app.workspace.getLeavesOfType(kanbanViewType);
 
     kanbanLeaves.forEach((leaf) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ export default class KanbanPlugin extends Plugin {
   dbTimers: { [id: string]: number } = {};
   hasSet: { [id: string]: boolean } = {};
   appEl: HTMLDivElement;
-  views: DataBridge<Set<KanbanView>> = new DataBridge(new Set)
+  views: DataBridge<Map<string,KanbanView>> = new DataBridge(new Map);
 
   async onload() {
     const self = this;
@@ -224,15 +224,15 @@ export default class KanbanPlugin extends Plugin {
 
   addView(view: KanbanView) {
     const views = this.views.getData()
-    if (!views.has(view)) {
-      this.views.setExternal(update(views, {$add: [view]}))
+    if (!views.has(view.id)) {
+      this.views.setExternal(update(views, {$add: [[view.id, view]]}))
     }
   }
 
   removeView(view: KanbanView) {
     const views = this.views.getData()
-    if (views.has(view)) {
-      this.views.setExternal(update(views, {$remove: [view]}))
+    if (views.has(view.id)) {
+      this.views.setExternal(update(views, {$remove: [view.id]}))
     }
   }
 


### PR DESCRIPTION
These changes should fix some of the problems, *possibly* including #178.

Regarding performance, the first level of fixes I know how to do are parsing/unparsing (boardToMd/mdToBoard).  Specifically, the parser needs to maintain incremental state, so that item IDs are fixed (to prevent re-rendering the whole board for every change) and to avoid the need to parse lines that haven't changed.  I've already got a draft of that, but it needs some cleanup.

A complicating factor is the board settings.  Right now everything is basically using a typed bag of props and dynamically determining defaults, and it's not clear to me whether everything updates correctly when you change settings.  (Or conversely, if settings actually update *too often*.)

To summarize the future plans: I'd like to 

1. Make an object for "here are the board's *complete* current settings, that don't need you to access the view or the plugin in order to get a value from them, and don't need you to compile regexes or figure out default values".
2. Consolidate parsing operations to a parser object that uses the aforementioned settings object, and make that parser do incremental parsing and unparsing.  (If that sounds complicated, it really isn't -- basically just two caches for string -> item and item -> string, with a little glue logic to set up consistent IDs.  The actual logic will be barely touched except for some cache lookups)
3. Have the previous two objects on the view become part of the board state, context, or props, ideally replacing all direct access to the `view` within the component tree.  (Among other things, this will help do embeds later, as they don't really have a "view" per se, or at least not one they can manipulate in the same way.)

I'm hoping this will be enough to get within walking distance of a reasonable update typing speed on large boards, even prior to any more expansive refactoring or dnd replacement.