### PR TITLE
Parser refactoring (WIP but merge any time)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "npm:@preact/compat",
     "react-beautiful-dnd": "^13.1.0",
     "react-cool-onclickoutside": "^1.6.1",
-    "react-dom": "npm:@preact/compat",
-    "use-bus": "^2.3.1"
+    "react-dom": "npm:@preact/compat"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/diff": "^5.0.0",
     "@types/node": "^14.14.37",
     "cross-env": "^7",
     "obsidian": "^0.12.5",
@@ -26,6 +27,7 @@
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^17.0.3",
     "choices.js": "^9.0.1",
+    "diff": "^5.0.0",
     "flatpickr": "^4.6.9",
     "fuse.js": "^6.4.6",
     "immutability-helper": "^3.1.1",

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -9,6 +9,7 @@ import {
   WorkspaceLeaf,
   moment,
   TFile,
+  MarkdownRenderer,
 } from "obsidian";
 import { dispatch } from "use-bus";
 
@@ -307,6 +308,37 @@ export class KanbanView extends TextFileView implements HoverParent {
           />
         </ErrorHandler>
       );
+  }
+
+  renderMarkdown(markdownString: string): HTMLElement {
+    const tempEl = createDiv();
+    MarkdownRenderer.renderMarkdown(
+      markdownString,
+      tempEl,
+      this.file?.path,
+      this
+    );
+    tempEl.findAll(".internal-embed").forEach((el) => {
+      const src = el.getAttribute("src");
+      const target =
+        typeof src === "string" &&
+        this.app.metadataCache.getFirstLinkpathDest(src, this.file?.path);
+      if (target instanceof TFile && target.extension !== "md") {
+        el.innerText = "";
+        el.createEl(
+          "img",
+          { attr: { src: this.app.vault.getResourcePath(target) } },
+          (img) => {
+            if (el.hasAttribute("width"))
+              img.setAttribute("width", el.getAttribute("width"));
+            if (el.hasAttribute("alt"))
+              img.setAttribute("alt", el.getAttribute("alt"));
+          }
+        );
+        el.addClasses(["image-embed", "is-loaded"]);
+      }
+    });
+    return tempEl;
   }
 }
 

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -66,10 +66,10 @@ export class KanbanView extends TextFileView implements HoverParent {
     this.plugin.removeView(this);
   }
 
-  getSetting(
-    key: keyof KanbanSettings,
+  getSetting<K extends keyof KanbanSettings>(
+    key: K,
     suppliedLocalSettings?: KanbanSettings
-  ) {
+  ): KanbanSettings[K] {
     const localSetting = suppliedLocalSettings
       ? suppliedLocalSettings[key]
       : this.dataBridge.getData()?.settings[key];
@@ -83,7 +83,7 @@ export class KanbanView extends TextFileView implements HoverParent {
     return null;
   }
 
-  getGlobalSetting(key: keyof KanbanSettings) {
+  getGlobalSetting<K extends keyof KanbanSettings>(key: K): KanbanSettings[K] {
     const globalSetting = this.plugin?.settings[key];
 
     if (globalSetting !== undefined) return globalSetting;

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -1,5 +1,4 @@
 import update from "immutability-helper";
-import ReactDOM from "react-dom";
 import React from "react";
 import {
   HoverParent,
@@ -172,6 +171,19 @@ export class KanbanView extends TextFileView implements HoverParent {
     */
   }
 
+  onload() {
+    super.onload();
+    this.registerEvent(this.app.workspace.on("quick-preview", this.onQuickPreview, this));
+  }
+
+  onQuickPreview(file: TFile, data: string) {
+    // File was edited in another window (but not yet saved)
+    if (file === this.file && data !== this.data) {
+      this.data = data;
+      this.setViewData(data);
+    }
+  }
+
   async onLoadFile(file: TFile) {
     try {
       return await super.onLoadFile(file);
@@ -190,6 +202,8 @@ export class KanbanView extends TextFileView implements HoverParent {
       if (this.data !== newData) {
         this.data = newData;
         this.requestSave();
+        // Tell other boards and editors we've changed
+        this.app.workspace.trigger("quick-preview", this.file, this.data);
       }
   };
 

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -256,13 +256,7 @@ export class KanbanView extends TextFileView implements HoverParent {
       newTitle.push(item.titleRaw);
 
       const titleRaw = newTitle.join(" ");
-      const processed = this.parser.processTitle(titleRaw);
-
-      return update(item, {
-        title: { $set: processed.title },
-        titleRaw: { $set: titleRaw },
-        titleSearch: { $set: processed.titleSearch },
-      });
+      return this.parser.updateItem(item, titleRaw);
     };
 
     const lanes = board.lanes.map((lane) => {

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -127,9 +127,10 @@ export class KanbanView extends TextFileView implements HoverParent {
                         $set: settings,
                       },
                     });
-                  // external updates display, internal updates the file
-                  this.dataBridge.setExternal(updatedBoard);
-                  this.dataBridge.setInternal(updatedBoard);
+                  // Save to disk, compute text of new board
+                  this.requestUpdate(updatedBoard);
+                  // Take the text and parse it back in with the new settings
+                  this.setViewData(this.data)
                 },
               },
               board.settings
@@ -207,7 +208,7 @@ export class KanbanView extends TextFileView implements HoverParent {
     return this.data;
   }
 
-  setViewData(data: string, clear: boolean) {
+  setViewData(data: string, _clear?: boolean) {
     const trimmedContent = data.trim();
     let board: Board = null;
     try {
@@ -217,7 +218,7 @@ export class KanbanView extends TextFileView implements HoverParent {
             settings: { "kanban-plugin": "basic" },
             isSearching: false,
           };
-      if (trimmedContent) board = this.parser.mdToBoard(trimmedContent);
+      if (trimmedContent) board = this.parser.mdToBoard(trimmedContent, this.file?.path);
       this.setError()
     } catch (e) {
       console.error(e);

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -11,7 +11,6 @@ import {
   TFile,
   MarkdownRenderer,
 } from "obsidian";
-import { dispatch } from "use-bus";
 
 import { KanbanParser } from "./parser";
 import { Kanban } from "./components/Kanban";
@@ -93,7 +92,9 @@ export class KanbanView extends TextFileView implements HoverParent {
   }
 
   onFileMetadataChange(file: TFile) {
-    dispatch(`metadata:update:${file.path}`);
+    // Invalidate the metadata caching and reparse the file if needed,
+    // recreating all items that referenced the changed file
+    if (this.parser.invalidateFile(file)) this.setViewData(this.data);
   }
 
   onMoreOptionsMenu(menu: Menu) {

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -12,7 +12,7 @@ import {
 } from "obsidian";
 import { dispatch } from "use-bus";
 
-import { boardToMd, mdToBoard, processTitle } from "./parser";
+import { KanbanParser } from "./parser";
 import { Kanban } from "./components/Kanban";
 import { DataBridge } from "./DataBridge";
 import { Board, Item } from "./components/types";
@@ -29,6 +29,7 @@ export const kanbanIcon = "blocks";
 
 export class KanbanView extends TextFileView implements HoverParent {
   plugin: KanbanPlugin;
+  parser: KanbanParser = new KanbanParser(this);
 
   dataBridge: DataBridge<Board> = new DataBridge(null);
   setBoard(board: Board) { this.dataBridge.setExternal(board); }
@@ -184,7 +185,7 @@ export class KanbanView extends TextFileView implements HoverParent {
 
   requestUpdate = (data: Board) => {
     if (data === null || this.getError().errorMessage) return; // don't save corrupt data
-      const newData = boardToMd(data)
+      const newData = this.parser.boardToMd(data)
       if (this.data !== newData) {
         this.data = newData;
         this.requestSave();
@@ -217,7 +218,7 @@ export class KanbanView extends TextFileView implements HoverParent {
             settings: { "kanban-plugin": "basic" },
             isSearching: false,
           };
-      if (trimmedContent) board = mdToBoard(trimmedContent, this);
+      if (trimmedContent) board = this.parser.mdToBoard(trimmedContent);
       this.setError()
     } catch (e) {
       console.error(e);
@@ -254,7 +255,7 @@ export class KanbanView extends TextFileView implements HoverParent {
       newTitle.push(item.titleRaw);
 
       const titleRaw = newTitle.join(" ");
-      const processed = processTitle(titleRaw, this);
+      const processed = this.parser.processTitle(titleRaw);
 
       return update(item, {
         title: { $set: processed.title },

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -20,10 +20,13 @@ import {
 } from "./helpers";
 import { t } from "src/lang/helpers";
 
-export interface DraggableItemFactoryParams {
-  items: Item[];
-  lane: Lane;
+export interface DraggableItemProps {
+  item: Item;
+  itemIndex: number;
+  shouldMarkItemsComplete: boolean;
   laneIndex: number;
+  provided: DraggableProvided;
+  snapshot: DraggableStateSnapshot;
 }
 
 interface GhostItemProps {
@@ -221,21 +224,16 @@ function ItemMenuButton({
   );
 }
 
-export function draggableItemFactory({
-  items,
-  lane,
+export function DraggableItem({
+  item,
+  itemIndex,
   laneIndex,
-}: DraggableItemFactoryParams) {
-  return (
-    provided: DraggableProvided,
-    snapshot: DraggableStateSnapshot,
-    rubric: DraggableRubric
-  ) => {
+  shouldMarkItemsComplete,
+  provided,
+  snapshot,
+}: DraggableItemProps) {
     const { boardModifiers, view, query } = React.useContext(ObsidianContext);
     const [isEditing, setIsEditing] = React.useState(false);
-
-    const itemIndex = rubric.source.index;
-    const item = items[itemIndex];
 
     const isMatch = query
       ? item.titleSearch.contains(query)
@@ -288,7 +286,7 @@ export function draggableItemFactory({
             <ItemCheckbox
               item={item}
               itemIndex={itemIndex}
-              shouldMarkItemsComplete={lane.data.shouldMarkItemsComplete}
+              shouldMarkItemsComplete={shouldMarkItemsComplete}
               laneIndex={laneIndex}
             />
             <ItemContent
@@ -348,5 +346,4 @@ export function draggableItemFactory({
         </div>
       </div>
     );
-  };
 }

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -6,7 +6,7 @@ import {
   DraggableRubric,
 } from "react-beautiful-dnd";
 
-import { Item } from "../types";
+import { Item, Lane } from "../types";
 import { c, noop } from "../helpers";
 import { Icon } from "../Icon/Icon";
 import { ObsidianContext } from "../context";
@@ -22,6 +22,7 @@ import { t } from "src/lang/helpers";
 
 export interface DraggableItemFactoryParams {
   items: Item[];
+  lane: Lane;
   laneIndex: number;
 }
 
@@ -80,7 +81,6 @@ export function GhostItem({ item, shouldMarkItemsComplete }: GhostItemProps) {
         <ItemMetadata
           isSettingsVisible={false}
           item={item}
-          refreshItem={noop}
         />
       </div>
     </div>
@@ -223,6 +223,7 @@ function ItemMenuButton({
 
 export function draggableItemFactory({
   items,
+  lane,
   laneIndex,
 }: DraggableItemFactoryParams) {
   return (
@@ -230,12 +231,11 @@ export function draggableItemFactory({
     snapshot: DraggableStateSnapshot,
     rubric: DraggableRubric
   ) => {
-    const { boardModifiers, board, view, query } = React.useContext(ObsidianContext);
+    const { boardModifiers, view, query } = React.useContext(ObsidianContext);
     const [isEditing, setIsEditing] = React.useState(false);
 
     const itemIndex = rubric.source.index;
     const item = items[itemIndex];
-    const lane = board.lanes[laneIndex];
 
     const isMatch = query
       ? item.titleSearch.contains(query)
@@ -260,22 +260,6 @@ export function draggableItemFactory({
       itemIndex,
       boardModifiers,
     });
-
-    const refreshItem = () => {
-      update(board, {
-        lanes: {
-          [laneIndex]: {
-            items: {
-              [itemIndex]: {
-                title: {
-                  $set: item.title,
-                },
-              },
-            },
-          },
-        },
-      });
-    };
 
     return (
       <div
@@ -360,7 +344,6 @@ export function draggableItemFactory({
             searchQuery={isMatch ? query : undefined}
             isSettingsVisible={isEditing}
             item={item}
-            refreshItem={refreshItem}
           />
         </div>
       </div>

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -224,16 +224,34 @@ function ItemMenuButton({
   );
 }
 
-export function DraggableItem({
-  item,
-  itemIndex,
-  laneIndex,
-  shouldMarkItemsComplete,
-  provided,
-  snapshot,
-}: DraggableItemProps) {
-    const { boardModifiers, view, query } = React.useContext(ObsidianContext);
-    const [isEditing, setIsEditing] = React.useState(false);
+type DraggableItemState = {
+  isEditing: boolean;
+}
+
+export class DraggableItem extends React.PureComponent<DraggableItemProps, DraggableItemState> {
+  static contextType = ObsidianContext;
+
+  state = {isEditing: false}
+
+  setIsEditing = (isEditing: boolean) => {
+    this.setState({isEditing});
+  }
+
+  showMenu = (e: MouseEvent, internalLinkPath?: string) => {
+    useItemMenu({
+      setIsEditing: this.setIsEditing,
+      item: this.props.item,
+      laneIndex: this.props.laneIndex,
+      itemIndex: this.props.itemIndex,
+      boardModifiers: this.context.boardModifiers,
+      view: this.context.view,
+    })(e, internalLinkPath);
+  }
+
+  render() {
+    const {item, itemIndex, laneIndex, shouldMarkItemsComplete, provided, snapshot} = this.props;
+    const { boardModifiers, view, query } = this.context;
+    const { isEditing } = this.state;
 
     const isMatch = query
       ? item.titleSearch.contains(query)
@@ -251,14 +269,6 @@ export function DraggableItem({
       }
     }
 
-    const showMenu = useItemMenu({
-      setIsEditing,
-      item,
-      laneIndex,
-      itemIndex,
-      boardModifiers,
-    });
-
     return (
       <div
         onContextMenu={(e) => {
@@ -271,10 +281,10 @@ export function DraggableItem({
               ? e.target.dataset.href
               : undefined;
 
-          showMenu(e.nativeEvent, internalLinkPath);
+          this.showMenu(e.nativeEvent, internalLinkPath);
         }}
         onDoubleClick={() => {
-          setIsEditing(true);
+          this.setIsEditing(true);
         }}
         className={`${c("item")} ${classModifiers.join(" ")}`}
         ref={provided.innerRef}
@@ -291,7 +301,7 @@ export function DraggableItem({
             />
             <ItemContent
               isSettingsVisible={isEditing}
-              setIsSettingsVisible={setIsEditing}
+              setIsSettingsVisible={this.setIsEditing}
               item={item}
               searchQuery={isMatch ? query : undefined}
               onChange={(e) => {
@@ -334,8 +344,8 @@ export function DraggableItem({
             />
             <ItemMenuButton
               isEditing={isEditing}
-              setIsEditing={setIsEditing}
-              showMenu={showMenu}
+              setIsEditing={this.setIsEditing}
+              showMenu={this.showMenu}
             />
           </div>
           <ItemMetadata
@@ -346,4 +356,5 @@ export function DraggableItem({
         </div>
       </div>
     );
+  }
 }

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -209,9 +209,9 @@ function ItemMenuButton({
         </button>
       ) : (
         <button
-          onClick={(e) => {
-            showMenu(e.nativeEvent);
-          }}
+          onClick={
+            showMenu
+          }
           className={c("item-postfix-button")}
           aria-label={t("More options")}
         >

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -101,7 +101,7 @@ function ItemCheckbox({
   item,
 }: ItemCheckboxProps) {
   const { view } = React.useContext(ObsidianContext);
-  const { boardModifiers } = React.useContext(KanbanContext);
+  const boardModifiers = React.useContext(KanbanContext);
   const shouldShowCheckbox = view.getSetting("show-checkboxes");
 
   const [isCtrlHoveringCheckbox, setIsCtrlHoveringCheckbox] =

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -9,7 +9,7 @@ import {
 import { Item } from "../types";
 import { c, noop } from "../helpers";
 import { Icon } from "../Icon/Icon";
-import { KanbanContext, ObsidianContext, SearchContext } from "../context";
+import { ObsidianContext } from "../context";
 import { ItemContent, ItemMetadata } from "./ItemContent";
 import { useItemMenu } from "./ItemMenu";
 import {
@@ -100,8 +100,7 @@ function ItemCheckbox({
   itemIndex,
   item,
 }: ItemCheckboxProps) {
-  const { view } = React.useContext(ObsidianContext);
-  const boardModifiers = React.useContext(KanbanContext);
+  const { view, boardModifiers } = React.useContext(ObsidianContext);
   const shouldShowCheckbox = view.getSetting("show-checkboxes");
 
   const [isCtrlHoveringCheckbox, setIsCtrlHoveringCheckbox] =
@@ -231,9 +230,7 @@ export function draggableItemFactory({
     snapshot: DraggableStateSnapshot,
     rubric: DraggableRubric
   ) => {
-    const { boardModifiers, board } = React.useContext(KanbanContext);
-    const { view } = React.useContext(ObsidianContext);
-    const { query } = React.useContext(SearchContext);
+    const { boardModifiers, board, view, query } = React.useContext(ObsidianContext);
     const [isEditing, setIsEditing] = React.useState(false);
 
     const itemIndex = rubric.source.index;

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -210,7 +210,7 @@ function ItemMenuButton({
       ) : (
         <button
           onClick={
-            showMenu
+             showMenu as unknown as React.MouseEventHandler<HTMLButtonElement>
           }
           className={c("item-postfix-button")}
           aria-label={t("More options")}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -317,16 +317,10 @@ export function draggableItemFactory({
               searchQuery={isMatch ? query : undefined}
               onChange={(e) => {
                 const titleRaw = e.target.value.replace(/[\r\n]+/g, " ");
-                const processed = view.parser.processTitle(titleRaw);
                 boardModifiers.updateItem(
                   laneIndex,
                   itemIndex,
-                  update(item, {
-                    title: { $set: processed.title },
-                    titleRaw: { $set: titleRaw },
-                    titleSearch: { $set: processed.titleSearch },
-                    metadata: { $set: processed.metadata },
-                  })
+                  view.parser.updateItem(item, titleRaw)
                 );
               }}
               onEditDate={(e) => {

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -210,7 +210,7 @@ function ItemMenuButton({
       ) : (
         <button
           onClick={
-             showMenu as unknown as React.MouseEventHandler<HTMLButtonElement>
+            showMenu as unknown as React.MouseEventHandler<HTMLButtonElement>
           }
           className={c("item-postfix-button")}
           aria-label={t("More options")}
@@ -241,7 +241,7 @@ export function draggableItemFactory({
     const lane = board.lanes[laneIndex];
 
     const isMatch = query
-      ? item.titleSearch.toLocaleLowerCase().contains(query)
+      ? item.titleSearch.contains(query)
       : false;
 
     const classModifiers: string[] = getClassModifiers(item);

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -12,7 +12,6 @@ import { Icon } from "../Icon/Icon";
 import { KanbanContext, ObsidianContext, SearchContext } from "../context";
 import { ItemContent, ItemMetadata } from "./ItemContent";
 import { useItemMenu } from "./ItemMenu";
-import { processTitle } from "src/parser";
 import {
   constructDatePicker,
   constructMenuDatePickerOnChange,
@@ -318,7 +317,7 @@ export function draggableItemFactory({
               searchQuery={isMatch ? query : undefined}
               onChange={(e) => {
                 const titleRaw = e.target.value.replace(/[\r\n]+/g, " ");
-                const processed = processTitle(titleRaw, view);
+                const processed = view.parser.processTitle(titleRaw);
                 boardModifiers.updateItem(
                   laneIndex,
                   itemIndex,

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -1,6 +1,5 @@
 import { getLinkpath, moment } from "obsidian";
 import React from "react";
-import useBus from "use-bus";
 
 import { Item, PageData } from "../types";
 import { c, getDefaultDateFormat, getDefaultTimeFormat } from "../helpers";
@@ -266,21 +265,13 @@ export interface ItemMetadataProps {
   item: Item;
   isSettingsVisible: boolean;
   searchQuery?: string;
-  refreshItem: () => void;
 }
 
 export function ItemMetadata({
   item,
   isSettingsVisible,
-  refreshItem,
   searchQuery,
 }: ItemMetadataProps) {
-  useBus(
-    `metadata:update:${item.metadata.file?.path || "null"}`,
-    () => refreshItem(),
-    [item.metadata.file]
-  );
-
   if (isSettingsVisible || !item.metadata.fileMetadata) return null;
 
   return (

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -344,7 +344,7 @@ export const ItemContent = React.memo(
       <div className={c("item-title")}>
         <MarkdownRenderer
           className={c("item-markdown")}
-          markdownString={item.title}
+          dom={item.dom}
           searchQuery={searchQuery}
         />
         <div className={c("item-metadata")}>

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -11,7 +11,6 @@ import { Item } from "../types";
 import { c, generateInstanceId } from "../helpers";
 import { useAutocompleteInputProps } from "./autocomplete";
 import { ObsidianContext } from "../context";
-import { processTitle } from "src/parser";
 import { t } from "src/lang/helpers";
 import { KanbanView } from "src/KanbanView";
 
@@ -158,7 +157,7 @@ export function ItemForm({ addItems }: ItemFormProps) {
   const addItemsFromStrings = (titles: string[]) => {
     addItems(
       titles.map((title) => {
-        const processed = processTitle(title, view);
+        const processed = view.parser.processTitle(title);
         const newItem: Item = {
           id: generateInstanceId(),
           title: processed.title,

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -156,18 +156,7 @@ export function ItemForm({ addItems }: ItemFormProps) {
 
   const addItemsFromStrings = (titles: string[]) => {
     addItems(
-      titles.map((title) => {
-        const processed = view.parser.processTitle(title);
-        const newItem: Item = {
-          id: generateInstanceId(),
-          title: processed.title,
-          titleRaw: title,
-          titleSearch: processed.titleSearch,
-          data: {},
-          metadata: processed.metadata,
-        };
-        return newItem;
-      })
+      titles.map((title) => view.parser.newItem(title))
     );
   };
 

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -83,16 +83,11 @@ export function useItemMenu({
               prevTitle,
               `[[${sanitizedTitle}]]`
             );
-            const processed = view.parser.processTitle(newTitleRaw);
 
             boardModifiers.updateItem(
               laneIndex,
               itemIndex,
-              update(item, {
-                title: { $set: processed.title },
-                titleRaw: { $set: newTitleRaw },
-                titleSearch: { $set: processed.titleSearch },
-              })
+              view.parser.updateItem(item, newTitleRaw)
             );
           });
       })
@@ -150,17 +145,10 @@ export function useItemMenu({
             );
 
             const titleRaw = item.titleRaw.replace(dateRegEx, "").trim();
-            const processed = view.parser.processTitle(titleRaw);
-
             boardModifiers.updateItem(
               laneIndex,
               itemIndex,
-              update(item, {
-                title: { $set: processed.title },
-                titleRaw: { $set: titleRaw },
-                titleSearch: { $set: processed.titleSearch },
-                metadata: { $set: processed.metadata },
-              })
+              view.parser.updateItem(item, titleRaw)
             );
           });
       });
@@ -197,17 +185,10 @@ export function useItemMenu({
               );
 
               const titleRaw = item.titleRaw.replace(timeRegEx, "").trim();
-              const processed = view.parser.processTitle(titleRaw);
-
               boardModifiers.updateItem(
                 laneIndex,
                 itemIndex,
-                update(item, {
-                  title: { $set: processed.title },
-                  titleRaw: { $set: titleRaw },
-                  titleSearch: { $set: processed.titleSearch },
-                  metadata: { $set: processed.metadata },
-                })
+                view.parser.updateItem(item, titleRaw)
               );
             });
         });

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -33,8 +33,7 @@ export function useItemMenu({
 }: UseItemMenuParams) {
   const { view } = React.useContext(ObsidianContext);
 
-  return React.useMemo(() => {
-    const coordinates = { x: 0, y: 0 };
+  const openMenu = (coordinates = { x: 0, y: 0 }) => {
 
     const hasDate = !!item.metadata.date;
     const hasTime = !!item.metadata.time;
@@ -195,10 +194,10 @@ export function useItemMenu({
       }
     }
 
-    return (e: MouseEvent, internalLinkPath?: string) => {
-      coordinates.x = e.clientX;
-      coordinates.y = e.clientY;
+    menu.showAtPosition(coordinates);
+  };
 
+  return (e: MouseEvent, internalLinkPath?: string) => {
       if (internalLinkPath) {
         // @ts-ignore
         view.app.workspace.onLinkContextMenu(
@@ -207,8 +206,7 @@ export function useItemMenu({
           view.file.path
         );
       } else {
-        menu.showAtPosition(coordinates);
+        openMenu({x: e.clientX, y: e.clientY});
       }
-    };
-  }, [view, setIsEditing, boardModifiers, laneIndex, itemIndex, item]);
+  }
 }

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -5,7 +5,6 @@ import React from "react";
 import { BoardModifiers, Item } from "../types";
 import { applyTemplate, escapeRegExpStr } from "../helpers";
 import { ObsidianContext } from "../context";
-import { processTitle } from "src/parser";
 import { defaultDateTrigger, defaultTimeTrigger } from "src/settingHelpers";
 import {
   constructDatePicker,
@@ -84,7 +83,7 @@ export function useItemMenu({
               prevTitle,
               `[[${sanitizedTitle}]]`
             );
-            const processed = processTitle(newTitleRaw, view);
+            const processed = view.parser.processTitle(newTitleRaw);
 
             boardModifiers.updateItem(
               laneIndex,
@@ -151,7 +150,7 @@ export function useItemMenu({
             );
 
             const titleRaw = item.titleRaw.replace(dateRegEx, "").trim();
-            const processed = processTitle(titleRaw, view);
+            const processed = view.parser.processTitle(titleRaw);
 
             boardModifiers.updateItem(
               laneIndex,
@@ -198,7 +197,7 @@ export function useItemMenu({
               );
 
               const titleRaw = item.titleRaw.replace(timeRegEx, "").trim();
-              const processed = processTitle(titleRaw, view);
+              const processed = view.parser.processTitle(titleRaw);
 
               boardModifiers.updateItem(
                 laneIndex,

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -13,6 +13,7 @@ import {
   constructTimePicker,
 } from "./helpers";
 import { t } from "src/lang/helpers";
+import { KanbanView } from "src/KanbanView";
 
 const illegalCharsRegEx = /[\\/:"*?<>|]+/g;
 
@@ -22,6 +23,7 @@ interface UseItemMenuParams {
   laneIndex: number;
   itemIndex: number;
   boardModifiers: BoardModifiers;
+  view: KanbanView;
 }
 
 export function useItemMenu({
@@ -30,8 +32,8 @@ export function useItemMenu({
   laneIndex,
   itemIndex,
   boardModifiers,
+  view
 }: UseItemMenuParams) {
-  const { view } = React.useContext(ObsidianContext);
 
   const openMenu = (coordinates = { x: 0, y: 0 }) => {
 

--- a/src/components/Item/helpers.ts
+++ b/src/components/Item/helpers.ts
@@ -10,7 +10,6 @@ import {
 } from "../helpers";
 
 import flatpickr from "flatpickr";
-import { processTitle } from "src/parser";
 import { defaultDateTrigger, defaultTimeTrigger } from "src/settingHelpers";
 import { getDefaultLocale } from "./datePickerLocale";
 import { KanbanView } from "src/KanbanView";
@@ -127,7 +126,7 @@ export function constructMenuDatePickerOnChange({
       titleRaw = `${item.titleRaw} ${dateTrigger}${wrappedDate}`;
     }
 
-    const processed = processTitle(titleRaw, view);
+    const processed = view.parser.processTitle(titleRaw);
 
     boardModifiers.updateItem(
       laneIndex,
@@ -298,7 +297,7 @@ export function constructMenuTimePickerOnChange({
       titleRaw = `${item.titleRaw} ${timeTrigger}{${time}}`;
     }
 
-    const processed = processTitle(titleRaw, view);
+    const processed = view.parser.processTitle(titleRaw);
 
     boardModifiers.updateItem(
       laneIndex,

--- a/src/components/Item/helpers.ts
+++ b/src/components/Item/helpers.ts
@@ -126,17 +126,10 @@ export function constructMenuDatePickerOnChange({
       titleRaw = `${item.titleRaw} ${dateTrigger}${wrappedDate}`;
     }
 
-    const processed = view.parser.processTitle(titleRaw);
-
     boardModifiers.updateItem(
       laneIndex,
       itemIndex,
-      update(item, {
-        title: { $set: processed.title },
-        titleRaw: { $set: titleRaw },
-        titleSearch: { $set: processed.titleSearch },
-        metadata: { $set: processed.metadata },
-      })
+      view.parser.updateItem(item, titleRaw)
     );
   };
 }
@@ -297,17 +290,10 @@ export function constructMenuTimePickerOnChange({
       titleRaw = `${item.titleRaw} ${timeTrigger}{${time}}`;
     }
 
-    const processed = view.parser.processTitle(titleRaw);
-
     boardModifiers.updateItem(
       laneIndex,
       itemIndex,
-      update(item, {
-        title: { $set: processed.title },
-        titleRaw: { $set: titleRaw },
-        titleSearch: { $set: processed.titleSearch },
-        metadata: { $set: processed.metadata },
-      })
+      view.parser.updateItem(item, titleRaw)
     );
   };
 }

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -13,7 +13,7 @@ import {
 } from "./helpers";
 import { draggableLaneFactory } from "./Lane/Lane";
 import { LaneForm } from "./Lane/LaneForm";
-import { KanbanContext, ObsidianContext, SearchContext } from "./context";
+import { ObsidianContext } from "./context";
 import { KanbanView } from "src/KanbanView";
 import { frontMatterKey } from "../parser";
 import { t } from "src/lang/helpers";
@@ -396,11 +396,7 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
   );
 
   return (
-    <ObsidianContext.Provider value={ React.useMemo(() => ({view, filePath}), [view, filePath])}>
-      <KanbanContext.Provider value={ boardModifiers }>
-        <SearchContext.Provider
-          value={React.useMemo(() => ({ query: searchQuery.toLocaleLowerCase() }), [searchQuery])}
-        >
+    <ObsidianContext.Provider value={ React.useMemo(() => ({view, boardModifiers, filePath, query: searchQuery.toLocaleLowerCase()}), [view, boardModifiers, searchQuery, filePath])}>
           {boardData.isSearching && (
             <div className={c("search-wrapper")}>
               <input
@@ -447,8 +443,6 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
               {renderLanes}
             </Droppable>
           </div>
-        </SearchContext.Provider>
-      </KanbanContext.Provider>
     </ObsidianContext.Provider>
   );
 };

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -2,7 +2,7 @@ import { moment } from "obsidian";
 import update from "immutability-helper";
 import React from "react";
 import { DataBridge } from "../DataBridge";
-import { Droppable, DroppableProvided, Draggable } from "react-beautiful-dnd";
+import { Droppable, DroppableProvided, Draggable, DraggableProvided, DraggableStateSnapshot, DraggableRubric } from "react-beautiful-dnd";
 import { Board, BoardModifiers, Item, Lane } from "./types";
 import {
   c,
@@ -11,7 +11,7 @@ import {
   getDefaultTimeFormat,
   generateInstanceId,
 } from "./helpers";
-import { draggableLaneFactory } from "./Lane/Lane";
+import { DraggableLane } from "./Lane/Lane";
 import { LaneForm } from "./Lane/LaneForm";
 import { ObsidianContext } from "./context";
 import { KanbanView } from "src/KanbanView";
@@ -309,14 +309,30 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
 
   if (boardData === null) return null;
 
-  const renderLane = draggableLaneFactory({
-    lanes: boardData.lanes,
-  });
+  // These rendering functions can't usefully be memoized, because they all use boardData,
+  // which will always be "changed" when this component is re-rendered.
 
-  const renderLaneGhost = draggableLaneFactory({
-    lanes: boardData.lanes,
-    isGhost: true,
-  });
+  const renderLane = (
+    provided: DraggableProvided,
+    snapshot: DraggableStateSnapshot,
+    rubric: DraggableRubric
+  ) => (
+    <DraggableLane
+      lane={boardData.lanes[rubric.source.index]} laneIndex={rubric.source.index}
+      provided={provided} snapshot={snapshot}
+    />
+  );
+
+  const renderLaneGhost = (
+    provided: DraggableProvided,
+    snapshot: DraggableStateSnapshot,
+    rubric: DraggableRubric
+  ) => (
+    <DraggableLane
+      lane={boardData.lanes[rubric.source.index]} laneIndex={rubric.source.index} isGhost={true}
+      provided={provided} snapshot={snapshot}
+    />
+  );
 
   const renderLanes = (provided: DroppableProvided) => (
     <div

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -398,7 +398,7 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
   );
 
   return (
-    <ObsidianContext.Provider value={{ filePath, view }}>
+    <ObsidianContext.Provider value={ React.useMemo(() => ({view, filePath}), [view, filePath])}>
       <KanbanContext.Provider value={{ boardModifiers, board: boardData }}>
         <SearchContext.Provider
           value={{ query: searchQuery.toLocaleLowerCase() }}

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -54,13 +54,7 @@ function getBoardModifiers({
     newTitle.push(item.titleRaw);
 
     const titleRaw = newTitle.join(" ");
-    const processed = view.parser.processTitle(titleRaw);
-
-    return update(item, {
-      title: { $set: processed.title },
-      titleRaw: { $set: titleRaw },
-      titleSearch: { $set: processed.titleSearch },
-    });
+    return view.parser.updateItem(item, titleRaw);
   };
 
   return {

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -15,7 +15,7 @@ import { draggableLaneFactory } from "./Lane/Lane";
 import { LaneForm } from "./Lane/LaneForm";
 import { KanbanContext, ObsidianContext, SearchContext } from "./context";
 import { KanbanView } from "src/KanbanView";
-import { frontMatterKey, processTitle } from "../parser";
+import { frontMatterKey } from "../parser";
 import { t } from "src/lang/helpers";
 import { Icon } from "./Icon/Icon";
 
@@ -54,7 +54,7 @@ function getBoardModifiers({
     newTitle.push(item.titleRaw);
 
     const titleRaw = newTitle.join(" ");
-    const processed = processTitle(titleRaw, view);
+    const processed = view.parser.processTitle(titleRaw);
 
     return update(item, {
       title: { $set: processed.title },

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -26,13 +26,11 @@ interface KanbanProps {
 
 interface BoardStateProps {
   view: KanbanView;
-  boardData: Board;
-  setBoardData: React.Dispatch<Board>;
+  setBoardData: React.Dispatch<React.SetStateAction<Board>>;
 }
 
 function getBoardModifiers({
   view,
-  boardData,
   setBoardData,
 }: BoardStateProps): BoardModifiers {
   const shouldAppendArchiveDate = !!view.getSetting("prepend-archive-date");
@@ -63,7 +61,7 @@ function getBoardModifiers({
         view.app.workspace.trigger("kanban:card-added", view.file, item)
       );
 
-      setBoardData(
+      setBoardData((boardData) =>
         update(boardData, {
           lanes: {
             [laneIndex]: {
@@ -79,7 +77,7 @@ function getBoardModifiers({
     addLane: (lane: Lane) => {
       view.app.workspace.trigger("kanban:lane-added", view.file, lane);
 
-      setBoardData(
+      setBoardData((boardData) =>
         update(boardData, {
           lanes: {
             $push: [lane],
@@ -91,7 +89,7 @@ function getBoardModifiers({
     updateLane: (laneIndex: number, lane: Lane) => {
       view.app.workspace.trigger("kanban:lane-updated", view.file, lane);
 
-      setBoardData(
+      setBoardData((boardData) =>
         update(boardData, {
           lanes: {
             [laneIndex]: {
@@ -103,32 +101,32 @@ function getBoardModifiers({
     },
 
     deleteLane: (laneIndex: number) => {
-      view.app.workspace.trigger(
-        "kanban:lane-deleted",
-        view.file,
-        boardData.lanes[laneIndex]
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:lane-deleted",
+          view.file,
+          boardData.lanes[laneIndex]
+        );
 
-      setBoardData(
-        update(boardData, {
+        return update(boardData, {
           lanes: {
             $splice: [[laneIndex, 1]],
           },
-        })
-      );
+        });
+      })
     },
 
     archiveLane: (laneIndex: number) => {
-      view.app.workspace.trigger(
-        "kanban:lane-archived",
-        view.file,
-        boardData.lanes[laneIndex]
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:lane-archived",
+          view.file,
+          boardData.lanes[laneIndex]
+        );
 
       const items = boardData.lanes[laneIndex].items;
 
-      setBoardData(
-        update(boardData, {
+      return update(boardData, {
           lanes: {
             $splice: [[laneIndex, 1]],
           },
@@ -137,20 +135,20 @@ function getBoardModifiers({
               ? items.map(appendArchiveDate)
               : items,
           },
-        })
-      );
+        });
+      });
     },
 
     archiveLaneItems: (laneIndex: number) => {
-      const items = boardData.lanes[laneIndex].items;
-      view.app.workspace.trigger(
-        "kanban:lane-cards-archived",
-        view.file,
-        items
-      );
+      setBoardData((boardData) => {
+        const items = boardData.lanes[laneIndex].items;
+        view.app.workspace.trigger(
+          "kanban:lane-cards-archived",
+          view.file,
+          items
+        );
 
-      setBoardData(
-        update(boardData, {
+      return update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
@@ -164,18 +162,18 @@ function getBoardModifiers({
               : items,
           },
         })
-      );
+      });
     },
 
     deleteItem: (laneIndex: number, itemIndex: number) => {
-      view.app.workspace.trigger(
-        "kanban:card-deleted",
-        view.file,
-        boardData.lanes[laneIndex].items[itemIndex]
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:card-deleted",
+          view.file,
+          boardData.lanes[laneIndex].items[itemIndex]
+        );
 
-      setBoardData(
-        update(boardData, {
+        return update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
@@ -184,19 +182,19 @@ function getBoardModifiers({
             },
           },
         })
-      );
+      });
     },
 
     updateItem: (laneIndex: number, itemIndex: number, item: Item) => {
-      view.app.workspace.trigger(
-        "kanban:card-updated",
-        view.file,
-        boardData.lanes[laneIndex],
-        item
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:card-updated",
+          view.file,
+          boardData.lanes[laneIndex],
+          item
+        );
 
-      setBoardData(
-        update(boardData, {
+        return update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
@@ -207,19 +205,19 @@ function getBoardModifiers({
             },
           },
         })
-      );
+      });
     },
 
     archiveItem: (laneIndex: number, itemIndex: number, item: Item) => {
-      view.app.workspace.trigger(
-        "kanban:card-archived",
-        view.file,
-        boardData.lanes[laneIndex],
-        item
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:card-archived",
+          view.file,
+          boardData.lanes[laneIndex],
+          item
+        );
 
-      setBoardData(
-        update(boardData, {
+        return update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
@@ -231,28 +229,28 @@ function getBoardModifiers({
             $push: [shouldAppendArchiveDate ? appendArchiveDate(item) : item],
           },
         })
-      );
+      });
     },
 
     duplicateItem: (laneIndex: number, itemIndex: number) => {
-      view.app.workspace.trigger(
-        "kanban:card-duplicated",
-        view.file,
-        boardData.lanes[laneIndex],
-        itemIndex
-      );
+      setBoardData((boardData) => {
+        view.app.workspace.trigger(
+          "kanban:card-duplicated",
+          view.file,
+          boardData.lanes[laneIndex],
+          itemIndex
+        );
 
-      const itemWithNewID = update(
-        boardData.lanes[laneIndex].items[itemIndex],
-        {
-          id: {
-            $set: generateInstanceId(),
-          },
-        }
-      );
+        const itemWithNewID = update(
+          boardData.lanes[laneIndex].items[itemIndex],
+          {
+            id: {
+              $set: generateInstanceId(),
+            },
+          }
+        );
 
-      setBoardData(
-        update(boardData, {
+        return update(boardData, {
           lanes: {
             [laneIndex]: {
               items: {
@@ -261,7 +259,7 @@ function getBoardModifiers({
             },
           },
         })
-      );
+      });
     },
   };
 }
@@ -306,8 +304,8 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
   }, [boardData.archive.length, maxArchiveLength]);
 
   const boardModifiers = React.useMemo(() => {
-    return getBoardModifiers({ view, boardData, setBoardData });
-  }, [view, boardData, setBoardData]);
+    return getBoardModifiers({ view, setBoardData });
+  }, [view, setBoardData]);
 
   if (boardData === null) return null;
 
@@ -399,9 +397,9 @@ export const Kanban = ({view, dataBridge }: KanbanProps) => {
 
   return (
     <ObsidianContext.Provider value={ React.useMemo(() => ({view, filePath}), [view, filePath])}>
-      <KanbanContext.Provider value={{ boardModifiers, board: boardData }}>
+      <KanbanContext.Provider value={ boardModifiers }>
         <SearchContext.Provider
-          value={{ query: searchQuery.toLocaleLowerCase() }}
+          value={React.useMemo(() => ({ query: searchQuery.toLocaleLowerCase() }), [searchQuery])}
         >
           {boardData.isSearching && (
             <div className={c("search-wrapper")}>

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -14,7 +14,7 @@ import { c } from "../helpers";
 import { draggableItemFactory, GhostItem } from "../Item/Item";
 import { ItemForm } from "../Item/ItemForm";
 import { LaneHeader } from "./LaneHeader";
-import { KanbanContext, ObsidianContext, SearchContext } from "../context";
+import { ObsidianContext } from "../context";
 
 export interface DraggableLaneFactoryParams {
   lanes: Lane[];
@@ -90,8 +90,7 @@ export function draggableLaneFactory({
     snapshot: DraggableStateSnapshot,
     rubric: DraggableRubric
   ) => {
-    const boardModifiers = React.useContext(KanbanContext);
-    const { view } = React.useContext(ObsidianContext);
+    const { view, boardModifiers } = React.useContext(ObsidianContext);
     const lane = lanes[rubric.source.index];
     const shouldMarkItemsComplete = !!lane.data.shouldMarkItemsComplete;
     const laneWidth = view.getSetting("lane-width");

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -24,6 +24,7 @@ export interface DraggableLaneFactoryParams {
 interface LaneItemsProps {
   isGhost?: boolean;
   items: Item[];
+  lane: Lane;
   laneId: string;
   laneIndex: number;
   shouldMarkItemsComplete: boolean;
@@ -32,12 +33,14 @@ interface LaneItemsProps {
 function LaneItems({
   isGhost,
   items,
+  lane,
   laneId,
   laneIndex,
   shouldMarkItemsComplete,
 }: LaneItemsProps) {
   const renderItem = draggableItemFactory({
     laneIndex,
+    lane,
     items,
   });
 
@@ -120,6 +123,7 @@ export function draggableLaneFactory({
           lane={lane}
         />
         <LaneItems
+          lane={lane}
           laneId={lane.id}
           items={lane.items}
           laneIndex={rubric.source.index}

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -27,7 +27,6 @@ export interface DraggableLaneProps {
 interface LaneItemsProps {
   isGhost?: boolean;
   items: Item[];
-  lane: Lane;
   laneId: string;
   laneIndex: number;
   shouldMarkItemsComplete: boolean;
@@ -36,7 +35,6 @@ interface LaneItemsProps {
 function LaneItems({
   isGhost,
   items,
-  lane,
   laneId,
   laneIndex,
   shouldMarkItemsComplete,
@@ -51,10 +49,10 @@ function LaneItems({
       item={items[rubric.source.index]}
       itemIndex={rubric.source.index}
       laneIndex={laneIndex}
-      shouldMarkItemsComplete={lane.data.shouldMarkItemsComplete}
+      shouldMarkItemsComplete={shouldMarkItemsComplete}
       provided={provided} snapshot={snapshot}
     />
-  ), [laneIndex, items, lane.data.shouldMarkItemsComplete]);
+  ), [laneIndex, items, shouldMarkItemsComplete]);
 
   if (isGhost) {
     return (
@@ -132,7 +130,6 @@ export function DraggableLane({
           lane={lane}
         />
         <LaneItems
-          lane={lane}
           laneId={lane.id}
           items={lane.items}
           laneIndex={laneIndex}

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -94,14 +94,13 @@ function LaneItems({
   );
 }
 
-export function DraggableLane({
-  lane,
-  laneIndex,
-  isGhost,
-  provided,
-  snapshot,
-}: DraggableLaneProps) {
-    const { view, boardModifiers } = React.useContext(ObsidianContext);
+export class DraggableLane extends React.PureComponent<DraggableLaneProps>{
+
+  static contextType = ObsidianContext;
+
+  render() {
+    const {lane, laneIndex, isGhost, provided, snapshot} = this.props;
+    const { view, boardModifiers } = this.context;
     const shouldMarkItemsComplete = !!lane.data.shouldMarkItemsComplete;
     const laneWidth = view.getSetting("lane-width");
 
@@ -155,4 +154,5 @@ export function DraggableLane({
         />
       </div>
     );
+  }
 }

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -90,7 +90,7 @@ export function draggableLaneFactory({
     snapshot: DraggableStateSnapshot,
     rubric: DraggableRubric
   ) => {
-    const { boardModifiers } = React.useContext(KanbanContext);
+    const boardModifiers = React.useContext(KanbanContext);
     const { view } = React.useContext(ObsidianContext);
     const lane = lanes[rubric.source.index];
     const shouldMarkItemsComplete = !!lane.data.shouldMarkItemsComplete;

--- a/src/components/Lane/LaneForm.tsx
+++ b/src/components/Lane/LaneForm.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Lane } from "../types";
 import { c, generateInstanceId, useIMEInputProps } from "../helpers";
-import { KanbanContext } from "../context";
+import { ObsidianContext } from "../context";
 import useOnclickOutside from "react-cool-onclickoutside";
 import { t } from "src/lang/helpers";
 
 export function LaneForm() {
-  const { boardModifiers } = React.useContext(KanbanContext);
+  const { boardModifiers } = React.useContext(ObsidianContext);
   const [isInputVisible, setIsInputVisible] = React.useState(false);
   const [shouldMarkAsComplete, setShouldMarkAsComplete] = React.useState(false);
   const [laneTitle, setLaneTitle] = React.useState("");

--- a/src/components/Lane/LaneHeader.tsx
+++ b/src/components/Lane/LaneHeader.tsx
@@ -5,7 +5,7 @@ import { c } from "../helpers";
 import { GripIcon } from "../Icon/GripIcon";
 import { Icon } from "../Icon/Icon";
 import { DraggableProvidedDragHandleProps } from "react-beautiful-dnd";
-import { KanbanContext } from "../context";
+import { ObsidianContext } from "../context";
 import { LaneTitle } from "./LaneTitle";
 import { LaneSettings } from "./LaneSettings";
 import { useSettingsMenu, ConfirmAction } from "./LaneMenu";
@@ -19,7 +19,7 @@ interface LaneHeaderProps {
 
 export const LaneHeader = React.memo(
   ({ lane, laneIndex, dragHandleProps }: LaneHeaderProps) => {
-    const { boardModifiers } = React.useContext(KanbanContext);
+    const { boardModifiers } = React.useContext(ObsidianContext);
     const [isEditing, setIsEditing] = React.useState(false);
 
     const { settingsMenu, confirmAction, setConfirmAction } = useSettingsMenu({

--- a/src/components/Lane/LaneSettings.tsx
+++ b/src/components/Lane/LaneSettings.tsx
@@ -2,7 +2,7 @@ import update from "immutability-helper";
 import React from "react";
 import { Lane } from "../types";
 import { c } from "../helpers";
-import { KanbanContext } from "../context";
+import { ObsidianContext } from "../context";
 import { t } from "src/lang/helpers";
 
 export interface LaneSettingsProps {
@@ -11,7 +11,7 @@ export interface LaneSettingsProps {
 }
 
 export function LaneSettings({ lane, laneIndex }: LaneSettingsProps) {
-  const { boardModifiers } = React.useContext(KanbanContext);
+  const { boardModifiers } = React.useContext(ObsidianContext);
 
   return (
     <div className={c("lane-setting-wrapper")}>

--- a/src/components/Lane/LaneTitle.tsx
+++ b/src/components/Lane/LaneTitle.tsx
@@ -1,4 +1,4 @@
-import { getLinkpath, MarkdownRenderer } from "obsidian";
+import { getLinkpath } from "obsidian";
 import React from "react";
 import { t } from "src/lang/helpers";
 import { ObsidianContext } from "../context";
@@ -42,9 +42,7 @@ export function LaneTitle({
   }, [isEditing]);
 
   const markdownContent = React.useMemo(() => {
-    const tempEl = createDiv();
-    MarkdownRenderer.renderMarkdown(title, tempEl, filePath, view);
-
+    const tempEl = view.renderMarkdown(title);
     return {
       innerHTML: { __html: tempEl.innerHTML.toString() },
     };

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { MarkdownRenderer as ObsidianMarkdownRenderer, TFile } from "obsidian";
 import Mark from "mark.js";
 import { ObsidianContext } from "./context";
 
@@ -13,35 +12,7 @@ export const MarkdownRenderer = React.memo(
   ({ className, markdownString, searchQuery }: MarkdownRendererProps) => {
     const { view, filePath } = React.useContext(ObsidianContext);
     const markdownContent = React.useMemo(() => {
-      const tempEl = createDiv();
-      ObsidianMarkdownRenderer.renderMarkdown(
-        markdownString,
-        tempEl,
-        filePath,
-        view
-      );
-
-      tempEl.findAll(".internal-embed").forEach((el) => {
-        const src = el.getAttribute("src");
-        const target =
-          typeof src === "string" &&
-          view.app.metadataCache.getFirstLinkpathDest(src, filePath);
-        if (target instanceof TFile && target.extension !== "md") {
-          el.innerText = "";
-          el.createEl(
-            "img",
-            { attr: { src: view.app.vault.getResourcePath(target) } },
-            (img) => {
-              if (el.hasAttribute("width"))
-                img.setAttribute("width", el.getAttribute("width"));
-              if (el.hasAttribute("alt"))
-                img.setAttribute("alt", el.getAttribute("alt"));
-            }
-          );
-          el.addClasses(["image-embed", "is-loaded"]);
-        }
-      });
-
+      const tempEl = view.renderMarkdown(markdownString);
       if (searchQuery) {
         new Mark(tempEl).mark(searchQuery);
       }

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -26,7 +26,7 @@ export class MarkdownRenderer extends React.Component<MarkdownRendererProps, Mar
   }
 
   parse(props: MarkdownRendererProps) {
-    return props.dom.cloneNode(true) || this.context.view.renderMarkdown(this.props.markdownString);
+    return props.dom.cloneNode(true) || this.context.renderMarkdown(this.props.markdownString);
   }
 
   refreshState(props: MarkdownRendererProps, state: MarkdownRendererState={}) {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -4,23 +4,25 @@ import { ObsidianContext } from "./context";
 
 interface MarkdownRendererProps {
   className?: string;
-  markdownString: string;
+  markdownString?: string;
+  dom?: HTMLDivElement;
   searchQuery?: string;
 }
 
 export const MarkdownRenderer = React.memo(
-  ({ className, markdownString, searchQuery }: MarkdownRendererProps) => {
-    const { view, filePath } = React.useContext(ObsidianContext);
+  ({ className, dom, markdownString, searchQuery }: MarkdownRendererProps) => {
+    const { view } = React.useContext(ObsidianContext);
     const markdownContent = React.useMemo(() => {
-      const tempEl = view.renderMarkdown(markdownString);
+      let tempEl: HTMLDivElement = dom || view.renderMarkdown(markdownString);
       if (searchQuery) {
-        new Mark(tempEl).mark(searchQuery);
+        tempEl = tempEl.cloneNode(true) as HTMLDivElement;
+        new Mark(tempEl as HTMLDivElement).mark(searchQuery);
       }
 
       return {
         innerHTML: { __html: tempEl.innerHTML.toString() },
       };
-    }, [markdownString, filePath, view, searchQuery]);
+    }, [dom, markdownString, view, searchQuery]);
 
     return (
       <div

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Mark from "mark.js";
 import { ObsidianContext } from "./context";
+import { findDOMNode } from "react-dom";
 
 interface MarkdownRendererProps {
   className?: string;
@@ -9,26 +10,70 @@ interface MarkdownRendererProps {
   searchQuery?: string;
 }
 
-export const MarkdownRenderer = React.memo(
-  ({ className, dom, markdownString, searchQuery }: MarkdownRendererProps) => {
-    const { view } = React.useContext(ObsidianContext);
-    const markdownContent = React.useMemo(() => {
-      let tempEl: HTMLDivElement = dom || view.renderMarkdown(markdownString);
-      if (searchQuery) {
-        tempEl = tempEl.cloneNode(true) as HTMLDivElement;
-        new Mark(tempEl as HTMLDivElement).mark(searchQuery);
-      }
+interface MarkdownRendererState {
+  parsedEl?: HTMLDivElement
+  marker?: Mark;
+}
 
-      return {
-        innerHTML: { __html: tempEl.innerHTML.toString() },
-      };
-    }, [dom, markdownString, view, searchQuery]);
+export class MarkdownRenderer extends React.Component<MarkdownRendererProps, MarkdownRendererState> {
+  static contextType = ObsidianContext;
+  props: MarkdownRendererProps;
 
+  constructor(props: MarkdownRendererProps) {
+    super(props);
+    // Always maintain state
+    this.state = this.refreshState(props);
+  }
+
+  parse(props: MarkdownRendererProps) {
+    return props.dom.cloneNode(true) || this.context.view.renderMarkdown(this.props.markdownString);
+  }
+
+  refreshState(props: MarkdownRendererProps, state: MarkdownRendererState={}) {
+    let {parsedEl, marker} = state;
+    if (!parsedEl) parsedEl = this.parse(props);
+    if (!marker) {
+      marker = new Mark(parsedEl)
+    } else {
+      marker.unmark();
+    }
+    if (props.searchQuery) marker.mark(props.searchQuery);
+    return (parsedEl !== state.parsedEl || marker !== state.marker ) ? {parsedEl, marker} : state;
+  }
+
+  shouldComponentUpdate(nextProps: MarkdownRendererProps, nextState: MarkdownRendererState) {
+    // Ignore changes to state, as we only set state from componentDidUpdate
+    const res= (
+      nextProps.dom !== this.props.dom ||
+      nextProps.className !== this.props.className ||
+      nextProps.markdownString !== this.props.markdownString ||
+      nextProps.searchQuery !== this.props.searchQuery
+    );
+    return res
+  }
+
+  componentDidMount() {
+    findDOMNode(this).appendChild(this.state.parsedEl)
+  }
+
+  componentDidUpdate(prevProps: MarkdownRendererProps) {
+    let {parsedEl, marker} = this.state
+    if (this.props.dom !== prevProps.dom || this.props.markdownString !== prevProps.markdownString) {
+      const newState = {parsedEl, marker} = this.refreshState(this.props, {});
+      this.setState(newState)
+    } else if (this.props.searchQuery !== prevProps.searchQuery) {
+      marker.unmark();
+      if (this.props.searchQuery) marker.mark(this.props.searchQuery)
+    }
+    const me = findDOMNode(this), newDOM = parsedEl;
+    if (me.firstChild) me.replaceChild(newDOM, me.firstChild); else me.appendChild(newDOM);
+  }
+
+  render() {
     return (
       <div
-        className={`markdown-preview-view ${className || ""}`}
-        dangerouslySetInnerHTML={markdownContent.innerHTML}
+        className={`markdown-preview-view ${this.props.className || ""}`}
       />
     );
   }
-);
+}

--- a/src/components/context.ts
+++ b/src/components/context.ts
@@ -9,12 +9,7 @@ export interface ObsidianContextProps {
 
 export const ObsidianContext = React.createContext<ObsidianContextProps>(null);
 
-export interface KanbanContextProps {
-  board: Board;
-  boardModifiers: BoardModifiers;
-}
-
-export const KanbanContext = React.createContext<KanbanContextProps>(null);
+export const KanbanContext = React.createContext<BoardModifiers>(null);
 
 export interface SearchContextProps {
   query: string;

--- a/src/components/context.ts
+++ b/src/components/context.ts
@@ -1,18 +1,15 @@
 import React from "react";
 import { KanbanView } from "src/KanbanView";
-import { Board, BoardModifiers } from "./types";
+import { BoardModifiers } from "./types";
 
 export interface ObsidianContextProps {
   filePath?: string;
   view?: KanbanView;
+  boardModifiers:  BoardModifiers;
+  query: string;
 }
 
 export const ObsidianContext = React.createContext<ObsidianContextProps>(null);
 
-export const KanbanContext = React.createContext<BoardModifiers>(null);
 
-export interface SearchContextProps {
-  query: string;
-}
 
-export const SearchContext = React.createContext<SearchContextProps>(null);

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -47,6 +47,7 @@ export interface Item {
   titleSearch: string;
   metadata: ItemMetaData;
   data: ItemData;
+  dom: HTMLDivElement;
 }
 
 export interface Board {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -25,6 +25,7 @@ export default {
   // parser.ts
   Complete: "Complete",
   Archive: "Archive",
+  "Invalid Kanban file: problems parsing frontmatter": "Invalid Kanban file: problems parsing frontmatter",
 
   // settingHelpers.ts
   "Note: No template plugins are currently enabled.":

--- a/src/main.ts
+++ b/src/main.ts
@@ -332,7 +332,7 @@ export default class KanbanPlugin extends Plugin {
       type: "markdown",
       state: leaf.view.getState(),
       popstate: true,
-    } as ViewState);
+    } as ViewState, {focus: true});
   }
 
   async setKanbanView(leaf: WorkspaceLeaf) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { MarkdownRenderer, moment, TFile } from "obsidian";
+import { moment, TFile } from "obsidian";
 import {
   escapeRegExpStr,
   generateInstanceId,
@@ -11,6 +11,7 @@ import { defaultDateTrigger, defaultTimeTrigger } from "./settingHelpers";
 import yaml from "js-yaml";
 import { KanbanView } from "./KanbanView";
 import { t } from "./lang/helpers";
+import update from "immutability-helper";
 
 export const frontMatterKey = "kanban-plugin";
 
@@ -279,9 +280,30 @@ export class KanbanParser {
     return haveData ? metadata : undefined;
   }
 
-  processTitle(
+  newItem(titleRaw: string): Item {
+    const processed = this.processTitle(titleRaw);
+    return  {
+      id: generateInstanceId(),
+      title: processed.title,
+      titleRaw: titleRaw,
+      titleSearch: processed.titleSearch,
+      data: {},
+      metadata: processed.metadata,
+    }
+  }
+
+  updateItem(item: Item, titleRaw: string) {
+    const processed = this.processTitle(titleRaw);
+    return update(item, {
+      title: { $set: processed.title },
+      titleRaw: { $set: titleRaw },
+      titleSearch: { $set: processed.titleSearch },
+      metadata: { $set: processed.metadata },
+    });
+  }
+
+  private processTitle(
     title: string,
-    settings?: KanbanSettings
   ) {
     const date = this.extractDates(title);
     const tags = this.extractItemTags(date.processedTitle);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -74,8 +74,7 @@ export class KanbanParser {
     tags?: string[],
     fileMetadata?: FileMetadata
   ) {
-    const tempEl = createDiv();
-    MarkdownRenderer.renderMarkdown(title, tempEl, this.view.file.path, this.view);
+    const tempEl = this.view.renderMarkdown(title);
 
     let searchTitle = tempEl.innerText.trim();
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -103,7 +103,6 @@ export class KanbanParser {
 
   extractDates(
     title: string,
-    settings?: KanbanSettings
   ) {
     let date: undefined | moment.Moment = undefined;
     let time: undefined | moment.Moment = undefined;
@@ -166,7 +165,6 @@ export class KanbanParser {
 
   extractFirstLinkedFile(
     title: string,
-    settings?: KanbanSettings
   ) {
     if (!this.settings.metaKeys.length) {
       return null;
@@ -286,10 +284,10 @@ export class KanbanParser {
     title: string,
     settings?: KanbanSettings
   ) {
-    const date = this.extractDates(title, settings);
-    const tags = this.extractItemTags(date.processedTitle, settings);
-    const file = this.extractFirstLinkedFile(tags.processedTitle, settings);
-    const fileMetadata = this.getLinkedPageMetadata(file, settings);
+    const date = this.extractDates(title);
+    const tags = this.extractItemTags(date.processedTitle);
+    const file = this.extractFirstLinkedFile(tags.processedTitle);
+    const fileMetadata = this.getLinkedPageMetadata(file);
 
     return {
       title: tags.processedTitle.trim(),
@@ -310,7 +308,6 @@ export class KanbanParser {
 
   mdToItem(
     itemMd: string,
-    settings: KanbanSettings,
     isListItem?: boolean
   ): Item {
     let titleRaw = "";
@@ -328,7 +325,7 @@ export class KanbanParser {
       isComplete = match[3] !== " ";
     }
 
-    const processed = this.processTitle(titleRaw, settings);
+    const processed = this.processTitle(titleRaw);
 
     return {
       id: generateInstanceId(),

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -408,7 +408,7 @@ export class KanbanParser {
 
     const [beforeFrontMatter, frontMatter, body] = boardMd.split(/^---\r?$\n?/m, 3);
 
-    if (beforeFrontMatter.trim()) throw new Error("Invalid Kanban file: problems parsing frontmatter ")
+    if (beforeFrontMatter.trim()) throw new Error(t("Invalid Kanban file: problems parsing frontmatter"));
 
     const settings = (frontMatter === this.lastFrontMatter) ?
       this.lastSettings :

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -46,442 +46,440 @@ const archiveMarkerRegex = /^\*\*\*$/;
 const tagRegex = /(^|\s)(#[^#\s]+)/g;
 const linkRegex = /\[\[([^\|\]]+)(?:\||\]\])/;
 
-function itemToMd(item: Item) {
-  return `- [${item.data.isComplete ? "x" : " "}] ${item.titleRaw}`;
-}
 
-function getSearchTitle(
-  title: string,
-  view: KanbanView,
-  tags?: string[],
-  fileMetadata?: FileMetadata
-) {
-  const tempEl = createDiv();
-  MarkdownRenderer.renderMarkdown(title, tempEl, view.file.path, view);
+export class KanbanParser {
 
-  let searchTitle = tempEl.innerText.trim();
+  constructor(public view: KanbanView) {}
 
-  if (tags?.length) {
-    searchTitle += " " + tags.join(" ");
+  itemToMd(item: Item) {
+    return `- [${item.data.isComplete ? "x" : " "}] ${item.titleRaw}`;
   }
 
-  if (fileMetadata) {
-    const keys = Object.keys(fileMetadata).join(" ");
-    const values = Object.values(fileMetadata)
-      .map((v) => {
-        if (Array.isArray(v.value)) {
-          return v.value.join(" ");
-        }
+  getSearchTitle(
+    title: string,
+    tags?: string[],
+    fileMetadata?: FileMetadata
+  ) {
+    const tempEl = createDiv();
+    MarkdownRenderer.renderMarkdown(title, tempEl, this.view.file.path, this.view);
 
-        return v.value.toString();
-      })
-      .join(" ");
+    let searchTitle = tempEl.innerText.trim();
 
-    searchTitle += " " + keys + " " + values;
+    if (tags?.length) {
+      searchTitle += " " + tags.join(" ");
+    }
+
+    if (fileMetadata) {
+      const keys = Object.keys(fileMetadata).join(" ");
+      const values = Object.values(fileMetadata)
+        .map((v) => {
+          if (Array.isArray(v.value)) {
+            return v.value.join(" ");
+          }
+
+          return v.value.toString();
+        })
+        .join(" ");
+
+      searchTitle += " " + keys + " " + values;
+    }
+
+    return searchTitle;
   }
 
-  return searchTitle;
-}
+  extractDates(
+    title: string,
+    settings?: KanbanSettings
+  ) {
+    const dateFormat =
+      this.view.getSetting("date-format", settings) || getDefaultDateFormat(this.view.app);
+    const dateTrigger =
+      this.view.getSetting("date-trigger", settings) || defaultDateTrigger;
+    const timeFormat =
+      this.view.getSetting("time-format", settings) || getDefaultTimeFormat(this.view.app);
+    const timeTrigger =
+      this.view.getSetting("time-trigger", settings) || defaultTimeTrigger;
+    const shouldHideDate = this.view.getSetting("hide-date-in-title", settings);
+    const shouldLinkDate = this.view.getSetting("link-date-to-daily-note", settings);
 
-function extractDates(
-  title: string,
-  view: KanbanView,
-  settings?: KanbanSettings
-) {
-  const dateFormat =
-    view.getSetting("date-format", settings) || getDefaultDateFormat(view.app);
-  const dateTrigger =
-    view.getSetting("date-trigger", settings) || defaultDateTrigger;
-  const timeFormat =
-    view.getSetting("time-format", settings) || getDefaultTimeFormat(view.app);
-  const timeTrigger =
-    view.getSetting("time-trigger", settings) || defaultTimeTrigger;
-  const shouldHideDate = view.getSetting("hide-date-in-title", settings);
-  const shouldLinkDate = view.getSetting("link-date-to-daily-note", settings);
+    let date: undefined | moment.Moment = undefined;
+    let time: undefined | moment.Moment = undefined;
+    let processedTitle = title;
 
-  let date: undefined | moment.Moment = undefined;
-  let time: undefined | moment.Moment = undefined;
-  let processedTitle = title;
+    const contentMatch = shouldLinkDate ? "\\[\\[([^}]+)\\]\\]" : "{([^}]+)}";
+    const dateRegEx = new RegExp(
+      `(?:^|\\s)${escapeRegExpStr(dateTrigger as string)}${contentMatch}`
+    );
+    const timeRegEx = new RegExp(
+      `(?:^|\\s)${escapeRegExpStr(timeTrigger as string)}{([^}]+)}`
+    );
 
-  const contentMatch = shouldLinkDate ? "\\[\\[([^}]+)\\]\\]" : "{([^}]+)}";
-  const dateRegEx = new RegExp(
-    `(?:^|\\s)${escapeRegExpStr(dateTrigger as string)}${contentMatch}`
-  );
-  const timeRegEx = new RegExp(
-    `(?:^|\\s)${escapeRegExpStr(timeTrigger as string)}{([^}]+)}`
-  );
+    const dateMatch = dateRegEx.exec(title);
+    const timeMatch = timeRegEx.exec(title);
 
-  const dateMatch = dateRegEx.exec(title);
-  const timeMatch = timeRegEx.exec(title);
+    if (dateMatch) {
+      date = moment(dateMatch[1], dateFormat as string);
+    }
 
-  if (dateMatch) {
-    date = moment(dateMatch[1], dateFormat as string);
+    if (timeMatch) {
+      time = moment(timeMatch[1], timeFormat as string);
+
+      if (date) {
+        date.hour(time.hour());
+        date.minute(time.minute());
+
+        time = date.clone();
+      }
+    }
+
+    if (shouldHideDate) {
+      processedTitle = processedTitle
+        .replace(dateRegEx, "")
+        .replace(timeRegEx, "");
+    }
+
+    return {
+      date,
+      time,
+      processedTitle,
+    };
   }
 
-  if (timeMatch) {
-    time = moment(timeMatch[1], timeFormat as string);
+  extractItemTags(
+    title: string,
+    settings?: KanbanSettings
+  ) {
+    const shouldHideTags = this.view.getSetting("hide-tags-in-title", settings);
+    const tags: string[] = [];
 
-    if (date) {
-      date.hour(time.hour());
-      date.minute(time.minute());
+    let processedTitle = title;
+    let match = tagRegex.exec(title);
 
-      time = date.clone();
+    while (match != null) {
+      tags.push(match[2]);
+      match = tagRegex.exec(title);
+    }
+
+    if (shouldHideTags) {
+      processedTitle = processedTitle.replace(tagRegex, "$1");
+    }
+
+    return {
+      processedTitle,
+      tags,
+    };
+  }
+
+  extractFirstLinkedFile(
+    title: string,
+    settings?: KanbanSettings
+  ) {
+    const localKeys =
+      (this.view.getSetting("metadata-keys", settings) as DataKey[]) || [];
+    const globalKeys =
+      (this.view.getGlobalSetting("metadata-keys") as DataKey[]) || [];
+
+    if (localKeys.length === 0 && globalKeys?.length === 0) {
+      return null;
+    }
+
+    const match = title.match(linkRegex);
+
+    if (!match) {
+      return null;
+    }
+
+    const path = match[1];
+    const file = this.view.app.metadataCache.getFirstLinkpathDest(
+      path,
+      this.view.file.path
+    );
+
+    if (!file) {
+      return null;
+    }
+
+    return file;
+  }
+
+  getDataViewCache(file: TFile) {
+    if (
+      (this.view.app as any).plugins.enabledPlugins.has("dataview") &&
+      (this.view.app as any).plugins?.plugins?.dataview?.api
+    ) {
+      return (this.view.app as any).plugins.plugins.dataview.api.page(
+        file.path,
+        this.view.file.path
+      );
     }
   }
 
-  if (shouldHideDate) {
-    processedTitle = processedTitle
-      .replace(dateRegEx, "")
-      .replace(timeRegEx, "");
-  }
+  getLinkedPageMetadata(
+    file: TFile | null | undefined,
+    settings?: KanbanSettings
+  ): FileMetadata | undefined {
+    const globalKeys =
+      (this.view.getGlobalSetting("metadata-keys") as DataKey[]) || [];
+    const localKeys =
+      (this.view.getSetting("metadata-keys", settings) as DataKey[]) || [];
+    const keys = [...globalKeys, ...localKeys];
 
-  return {
-    date,
-    time,
-    processedTitle,
-  };
-}
-
-function extractItemTags(
-  title: string,
-  view: KanbanView,
-  settings?: KanbanSettings
-) {
-  const shouldHideTags = view.getSetting("hide-tags-in-title", settings);
-  const tags: string[] = [];
-
-  let processedTitle = title;
-  let match = tagRegex.exec(title);
-
-  while (match != null) {
-    tags.push(match[2]);
-    match = tagRegex.exec(title);
-  }
-
-  if (shouldHideTags) {
-    processedTitle = processedTitle.replace(tagRegex, "$1");
-  }
-
-  return {
-    processedTitle,
-    tags,
-  };
-}
-
-function extractFirstLinkedFile(
-  title: string,
-  view: KanbanView,
-  settings?: KanbanSettings
-) {
-  const localKeys =
-    (view.getSetting("metadata-keys", settings) as DataKey[]) || [];
-  const globalKeys =
-    (view.getGlobalSetting("metadata-keys") as DataKey[]) || [];
-
-  if (localKeys.length === 0 && globalKeys?.length === 0) {
-    return null;
-  }
-
-  const match = title.match(linkRegex);
-
-  if (!match) {
-    return null;
-  }
-
-  const path = match[1];
-  const file = view.app.metadataCache.getFirstLinkpathDest(
-    path,
-    view.file.path
-  );
-
-  if (!file) {
-    return null;
-  }
-
-  return file;
-}
-
-export function getDataViewCache(view: KanbanView, file: TFile) {
-  if (
-    (view.app as any).plugins.enabledPlugins.has("dataview") &&
-    (view.app as any).plugins?.plugins?.dataview?.api
-  ) {
-    return (view.app as any).plugins.plugins.dataview.api.page(
-      file.path,
-      view.file.path
-    );
-  }
-}
-
-export function getLinkedPageMetadata(
-  file: TFile | null | undefined,
-  view: KanbanView,
-  settings?: KanbanSettings
-): FileMetadata | undefined {
-  const globalKeys =
-    (view.getGlobalSetting("metadata-keys") as DataKey[]) || [];
-  const localKeys =
-    (view.getSetting("metadata-keys", settings) as DataKey[]) || [];
-  const keys = [...globalKeys, ...localKeys];
-
-  if (!keys.length) {
-    return;
-  }
-
-  if (!file) {
-    return;
-  }
-
-  const cache = view.app.metadataCache.getFileCache(file);
-  const dataviewCache = getDataViewCache(view, file);
-
-  if (!cache && !dataviewCache) {
-    return;
-  }
-
-  const metadata: FileMetadata = {};
-  const seenTags: { [k: string]: boolean } = {};
-  const seenKey: { [k: string]: boolean } = {};
-
-  let haveData = false;
-
-  keys.forEach((k) => {
-    if (seenKey[k.metadataKey]) return;
-
-    seenKey[k.metadataKey] = true;
-
-    if (k.metadataKey === "tags") {
-      let tags = cache?.tags || [];
-
-      if (cache?.frontmatter?.tags) {
-        tags = [].concat(
-          tags,
-          cache.frontmatter.tags.map((tag: string) => ({ tag: `#${tag}` }))
-        );
-      }
-
-      if (tags?.length === 0) return;
-
-      metadata.tags = {
-        ...k,
-        value: tags
-          .map((t) => t.tag)
-          .filter((t) => {
-            if (seenTags[t]) {
-              return false;
-            }
-
-            seenTags[t] = true;
-            return true;
-          }),
-      };
-
-      haveData = true;
+    if (!keys.length) {
       return;
     }
 
-    if (cache?.frontmatter && cache.frontmatter[k.metadataKey]) {
-      metadata[k.metadataKey] = {
-        ...k,
-        value: cache.frontmatter[k.metadataKey],
-      };
-      haveData = true;
-    } else if (dataviewCache && dataviewCache[k.metadataKey]) {
-      metadata[k.metadataKey] = {
-        ...k,
-        value: dataviewCache[k.metadataKey],
-      };
-      haveData = true;
+    if (!file) {
+      return;
     }
-  });
 
-  return haveData ? metadata : undefined;
-}
+    const cache = this.view.app.metadataCache.getFileCache(file);
+    const dataviewCache = this.getDataViewCache(file);
 
-export function processTitle(
-  title: string,
-  view: KanbanView,
-  settings?: KanbanSettings
-) {
-  const date = extractDates(title, view, settings);
-  const tags = extractItemTags(date.processedTitle, view, settings);
-  const file = extractFirstLinkedFile(tags.processedTitle, view, settings);
-  const fileMetadata = getLinkedPageMetadata(file, view, settings);
+    if (!cache && !dataviewCache) {
+      return;
+    }
 
-  return {
-    title: tags.processedTitle.trim(),
-    titleSearch: getSearchTitle(
-      tags.processedTitle,
-      view,
-      tags.tags,
-      fileMetadata
-    ),
-    metadata: {
-      date: date.date,
-      time: date.time,
-      tags: tags.tags,
-      file,
-      fileMetadata,
-    },
-  };
-}
+    const metadata: FileMetadata = {};
+    const seenTags: { [k: string]: boolean } = {};
+    const seenKey: { [k: string]: boolean } = {};
 
-function mdToItem(
-  itemMd: string,
-  view: KanbanView,
-  settings: KanbanSettings,
-  isListItem?: boolean
-): Item {
-  let titleRaw = "";
-  let isComplete = false;
+    let haveData = false;
 
-  if (isListItem) {
-    const match = itemMd.match(listRegex);
+    keys.forEach((k) => {
+      if (seenKey[k.metadataKey]) return;
 
-    titleRaw = match[3];
-    isComplete = false;
-  } else {
-    const match = itemMd.match(taskRegex);
+      seenKey[k.metadataKey] = true;
 
-    titleRaw = match[4];
-    isComplete = match[3] !== " ";
-  }
+      if (k.metadataKey === "tags") {
+        let tags = cache?.tags || [];
 
-  const processed = processTitle(titleRaw, view, settings);
+        if (cache?.frontmatter?.tags) {
+          tags = [].concat(
+            tags,
+            cache.frontmatter.tags.map((tag: string) => ({ tag: `#${tag}` }))
+          );
+        }
 
-  return {
-    id: generateInstanceId(),
-    title: processed.title,
-    titleSearch: processed.titleSearch,
-    titleRaw,
-    data: {
-      isComplete,
-    },
-    metadata: processed.metadata,
-  };
-}
+        if (tags?.length === 0) return;
 
-function laneToMd(lane: Lane) {
-  const lines: string[] = [];
+        metadata.tags = {
+          ...k,
+          value: tags
+            .map((t) => t.tag)
+            .filter((t) => {
+              if (seenTags[t]) {
+                return false;
+              }
 
-  lines.push(`## ${lane.title}`);
+              seenTags[t] = true;
+              return true;
+            }),
+        };
 
-  lines.push("");
+        haveData = true;
+        return;
+      }
 
-  if (lane.data.shouldMarkItemsComplete) {
-    lines.push(completeString);
-  }
-
-  lane.items.forEach((item) => {
-    lines.push(itemToMd(item));
-  });
-
-  lines.push("");
-  lines.push("");
-  lines.push("");
-
-  return lines.join("\n");
-}
-
-function archiveToMd(archive: Item[]) {
-  if (archive.length) {
-    const lines: string[] = [archiveString, "", `## ${t("Archive")}`, ""];
-
-    archive.forEach((item) => {
-      lines.push(itemToMd(item));
+      if (cache?.frontmatter && cache.frontmatter[k.metadataKey]) {
+        metadata[k.metadataKey] = {
+          ...k,
+          value: cache.frontmatter[k.metadataKey],
+        };
+        haveData = true;
+      } else if (dataviewCache && dataviewCache[k.metadataKey]) {
+        metadata[k.metadataKey] = {
+          ...k,
+          value: dataviewCache[k.metadataKey],
+        };
+        haveData = true;
+      }
     });
+
+    return haveData ? metadata : undefined;
+  }
+
+  processTitle(
+    title: string,
+    settings?: KanbanSettings
+  ) {
+    const date = this.extractDates(title, settings);
+    const tags = this.extractItemTags(date.processedTitle, settings);
+    const file = this.extractFirstLinkedFile(tags.processedTitle, settings);
+    const fileMetadata = this.getLinkedPageMetadata(file, settings);
+
+    return {
+      title: tags.processedTitle.trim(),
+      titleSearch: this.getSearchTitle(
+        tags.processedTitle,
+        tags.tags,
+        fileMetadata
+      ),
+      metadata: {
+        date: date.date,
+        time: date.time,
+        tags: tags.tags,
+        file,
+        fileMetadata,
+      },
+    };
+  }
+
+  mdToItem(
+    itemMd: string,
+    settings: KanbanSettings,
+    isListItem?: boolean
+  ): Item {
+    let titleRaw = "";
+    let isComplete = false;
+
+    if (isListItem) {
+      const match = itemMd.match(listRegex);
+
+      titleRaw = match[3];
+      isComplete = false;
+    } else {
+      const match = itemMd.match(taskRegex);
+
+      titleRaw = match[4];
+      isComplete = match[3] !== " ";
+    }
+
+    const processed = this.processTitle(titleRaw, settings);
+
+    return {
+      id: generateInstanceId(),
+      title: processed.title,
+      titleSearch: processed.titleSearch,
+      titleRaw,
+      data: {
+        isComplete,
+      },
+      metadata: processed.metadata,
+    };
+  }
+
+  laneToMd(lane: Lane) {
+    const lines: string[] = [];
+
+    lines.push(`## ${lane.title}`);
+
+    lines.push("");
+
+    if (lane.data.shouldMarkItemsComplete) {
+      lines.push(completeString);
+    }
+
+    lane.items.forEach((item) => {
+      lines.push(this.itemToMd(item));
+    });
+
+    lines.push("");
+    lines.push("");
+    lines.push("");
 
     return lines.join("\n");
   }
 
-  return "";
-}
+  archiveToMd(archive: Item[]) {
+    if (archive.length) {
+      const lines: string[] = [archiveString, "", `## ${t("Archive")}`, ""];
 
-export function settingsToFrontmatter(settings: KanbanSettings): string {
-  return ["---", "", yaml.dump(settings), "---", "", ""].join("\n");
-}
+      archive.forEach((item) => {
+        lines.push(this.itemToMd(item));
+      });
 
-export function boardToMd(board: Board) {
-  const lanes = board.lanes.reduce((md, lane) => {
-    return md + laneToMd(lane);
-  }, "");
+      return lines.join("\n");
+    }
 
-  return (
-    settingsToFrontmatter(board.settings) + lanes + archiveToMd(board.archive)
-  );
-}
-
-export function mdToSettings(boardMd: string): KanbanSettings {
-  const match = boardMd.match(frontmatterRegEx);
-
-  if (match) {
-    return yaml.load(match[1].trim()) as KanbanSettings;
+    return "";
   }
 
-  return { "kanban-plugin": "basic" };
-}
-
-export function mdToBoard(boardMd: string, view: KanbanView): Board {
-  const settings = mdToSettings(boardMd);
-  const lines = boardMd.replace(frontmatterRegEx, "").split(newLineRegex);
-  const lanes: Lane[] = [];
-  const archive: Item[] = [];
-
-  let haveSeenArchiveMarker = false;
-
-  let currentLane: Lane | null = null;
-
-  lines.forEach((line) => {
-    if (archiveMarkerRegex.test(line)) {
-      haveSeenArchiveMarker = true;
-    }
-
-    // New lane
-    if (!haveSeenArchiveMarker && laneRegex.test(line)) {
-      if (currentLane !== null) {
-        lanes.push(currentLane);
-      }
-
-      const match = line.match(laneRegex);
-
-      currentLane = {
-        id: generateInstanceId(),
-        items: [],
-        title: match[1],
-        data: {},
-      };
-
-      return;
-    }
-
-    // Check if this is a completed lane
-    if (!haveSeenArchiveMarker && completeRegex.test(line)) {
-      currentLane.data.shouldMarkItemsComplete = true;
-      return;
-    }
-
-    const isTask = taskRegex.test(line);
-    const isListItem = !isTask && listRegex.test(line);
-
-    // Create an item from tasks
-    if (isTask || isListItem) {
-      if (haveSeenArchiveMarker) {
-        archive.push(mdToItem(line, view, settings, isListItem));
-      } else {
-        currentLane.items.push(mdToItem(line, view, settings, isListItem));
-      }
-    }
-  });
-
-  // Push the last lane
-  if (currentLane) {
-    lanes.push(currentLane);
+  settingsToFrontmatter(settings: KanbanSettings): string {
+    return ["---", "", yaml.dump(settings), "---", "", ""].join("\n");
   }
 
-  return {
-    settings,
-    lanes,
-    archive,
-    isSearching: false,
-  };
+  boardToMd(board: Board) {
+    const lanes = board.lanes.reduce((md, lane) => {
+      return md + this.laneToMd(lane);
+    }, "");
+
+    return (
+      this.settingsToFrontmatter(board.settings) + lanes + this.archiveToMd(board.archive)
+    );
+  }
+
+  mdToSettings(boardMd: string): KanbanSettings {
+    const match = boardMd.match(frontmatterRegEx);
+
+    if (match) {
+      return yaml.load(match[1].trim()) as KanbanSettings;
+    }
+
+    return { "kanban-plugin": "basic" };
+  }
+
+  mdToBoard(boardMd: string): Board {
+    const settings = this.mdToSettings(boardMd);
+    const lines = boardMd.replace(frontmatterRegEx, "").split(newLineRegex);
+    const lanes: Lane[] = [];
+    const archive: Item[] = [];
+
+    let haveSeenArchiveMarker = false;
+
+    let currentLane: Lane | null = null;
+
+    lines.forEach((line) => {
+      if (archiveMarkerRegex.test(line)) {
+        haveSeenArchiveMarker = true;
+      }
+
+      // New lane
+      if (!haveSeenArchiveMarker && laneRegex.test(line)) {
+        if (currentLane !== null) {
+          lanes.push(currentLane);
+        }
+
+        const match = line.match(laneRegex);
+
+        currentLane = {
+          id: generateInstanceId(),
+          items: [],
+          title: match[1],
+          data: {},
+        };
+
+        return;
+      }
+
+      // Check if this is a completed lane
+      if (!haveSeenArchiveMarker && completeRegex.test(line)) {
+        currentLane.data.shouldMarkItemsComplete = true;
+        return;
+      }
+
+      const isTask = taskRegex.test(line);
+      const isListItem = !isTask && listRegex.test(line);
+
+      // Create an item from tasks
+      if (isTask || isListItem) {
+        if (haveSeenArchiveMarker) {
+          archive.push(this.mdToItem(line, settings, isListItem));
+        } else {
+          currentLane.items.push(this.mdToItem(line, settings, isListItem));
+        }
+      }
+    });
+
+    // Push the last lane
+    if (currentLane) {
+      lanes.push(currentLane);
+    }
+
+    return {
+      settings,
+      lanes,
+      archive,
+      isSearching: false,
+    };
+  }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,13 +71,12 @@ export class KanbanParser {
   }
 
   getSearchTitle(
+    dom: HTMLDivElement,
     title: string,
     tags?: string[],
     fileMetadata?: FileMetadata
   ) {
-    const tempEl = this.view.renderMarkdown(title);
-
-    let searchTitle = tempEl.innerText.trim();
+    let searchTitle = dom.innerText.trim();
 
     if (tags?.length) {
       searchTitle += " " + tags.join(" ");
@@ -289,6 +288,7 @@ export class KanbanParser {
       titleSearch: processed.titleSearch,
       data: {},
       metadata: processed.metadata,
+      dom: processed.dom,
     }
   }
 
@@ -299,6 +299,7 @@ export class KanbanParser {
       titleRaw: { $set: titleRaw },
       titleSearch: { $set: processed.titleSearch },
       metadata: { $set: processed.metadata },
+      dom: { $set: processed.dom },
     });
   }
 
@@ -309,10 +310,12 @@ export class KanbanParser {
     const tags = this.extractItemTags(date.processedTitle);
     const file = this.extractFirstLinkedFile(tags.processedTitle);
     const fileMetadata = this.getLinkedPageMetadata(file);
+    const dom = this.view.renderMarkdown(title);
 
     return {
       title: tags.processedTitle.trim(),
       titleSearch: this.getSearchTitle(
+        dom,
         tags.processedTitle,
         tags.tags,
         fileMetadata
@@ -324,6 +327,7 @@ export class KanbanParser {
         file,
         fileMetadata,
       },
+      dom
     };
   }
 
@@ -357,6 +361,7 @@ export class KanbanParser {
         isComplete,
       },
       metadata: processed.metadata,
+      dom: processed.dom,
     };
   }
 
@@ -490,9 +495,9 @@ export class KanbanParser {
       // Create an item from tasks
       if (isTask || isListItem) {
         if (haveSeenArchiveMarker) {
-          archive.push(this.mdToItem(line, settings, isListItem));
+          archive.push(this.mdToItem(line, isListItem));
         } else {
-          currentLane.items.push(this.mdToItem(line, settings, isListItem));
+          currentLane.items.push(this.mdToItem(line, isListItem));
         }
       }
     });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -480,14 +480,16 @@ export class KanbanParser {
         } else {
           // Using a cached item; verify its metadata and maybe fetch it again
           const file = item.metadata.file;
-          if (file && item.metadata.fileMetadata !== this.fileCache.get(file)) {
+          if (file) {
             let fileMetadata = this.fileCache.has(file) ? this.fileCache.get(file) : this.getLinkedPageMetadata(file);
             this.fileCache.set(file, fileMetadata);
-            // Make a new item with updated metadata
-            item = update(item, {
-              id: {$set: generateInstanceId()},
-              metadata: { fileMetadata: {$set: fileMetadata}}
-            });
+            if (item.metadata.fileMetadata !== fileMetadata) {
+              // Make a new item with updated metadata
+              item = update(item, {
+                id: {$set: generateInstanceId()},
+                metadata: { fileMetadata: {$set: fileMetadata}}
+              });
+            }
           }
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,11 +1608,6 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-use-bus@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/use-bus/-/use-bus-2.3.1.tgz#b96aebe753d99eca7cb6bd019a986d0f6eb1ca04"
-  integrity sha512-dAmoAiWmM0/YhrytHSt0zU0dJe1CW1HqsuTfe4w1mJaBOCGWe2SxSjyEXmZISgjbCRSJORtjtApYNDLxiWqGCg==
-
 use-memo-one@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,11 @@
   dependencies:
     "@types/tern" "*"
 
+"@types/diff@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-5.0.0.tgz#eb71e94feae62548282c4889308a3dfb57e36020"
+  integrity sha512-jrm2K65CokCCX4NmowtA+MfXyuprZC13jbRuwprs6/04z/EcFg/MCwYdsHn+zgV4CQBiATiI7AEq7y1sZCtWKA==
+
 "@types/estree@*":
   version "0.0.48"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.48.tgz#18dc8091b285df90db2f25aa7d906cfc394b7f74"
@@ -545,6 +550,11 @@ defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
So this is basically a branch to refactor the parser.  Why?

Well, parser performance is a significant part of initial view load, which can currently take multiple seconds for a board with a few hundred items.  Raw parse speed is a big part of that.

But it's also even more important for fixing #172, which requires using Obsidian's quick-preview events mechanism to co-ordinate updates between text files.  Currently, the blocker on using that is the fact that quick-preview basically means lots more parsing (at least when there is more than one view on the file open).  A simple caching mechanism to implement incremental parsing gets rid of most of the quick-preview overhead, but requires the parser to keep state.  (My original hack attempt at this kept that state in the view and passed it in as an argument, but that won't scale for the other changes needed to get the speed where it needs to be.)

Ultimately, the goal for this branch is to get incremental parse times down low enough that you can type without dropping keystrokes, while having a board open in two views (one of which could be an editor or preview view, and the typing either in the Kanban or the other view).  That's basically what it'll take to get quick-preview in place to fix #172, but also it'll be a big UX improvement vs parallel views only updating every two seconds.

Not all of that goal can be achieved by parsing alone, but improved parsing is a prerequisite for further performance improvements since non-incremental parsing means the entire board rendering *must* be repeated whenever the file changes.  Right now, fixing the parsing won't fix that due to the other non-repeatable bits, but it certainly doesn't help.  Incremental parsing however will ensure that only the actually changed/moved items will change as far as data sent to the rendering side of things, i.e. there will be a minimal change of the `Board`, with only affected Items actually changing in the data structure.

The harder goal is going to be to get initial parsing of a fresh board down to something reasonable.  It might be necessary to investigate using the metadata cache for initial parsing, since when opening a file the cache is very likely up to date.

Anyway, I figure I should push my progress here so you can keep an eye on it and make sure we don't conflict; feel free to merge as and when you like if you want to incorporate or test stuff; I'll just open a new PR to continue the branch if there's still work to be done.

After the initial commit (which just moved the parse functions into a class, no other changes), most of this work should only touch parser.ts, though later updates might hit KanbanView to manage recreating the parser when the global settings change or when switching to a new file (as a new cache will be needed).  I can also foresee wanting to replace components calling getSetting() with simple property access off a property on the Board data...  getting rid of all those calls to getDefaultDateFormat and the like as well.

Oh, and last but not least, I want to make the parser accept empty headings as titles, so that you don't corrupt your board by not giving a lane a title.  :grin:

