### PR TITLE
Parser fixes: more robust parsing, fix some outstanding issues

### DIFF
--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -363,7 +363,7 @@ class ErrorHandler extends React.Component<{view: KanbanView}> {
 
   constructor(props: {view: KanbanView}) {
     super(props);
-    this.state = { errorMessage: "" };
+    this.state = this.props.view.errorBridge.getData();
   }
 
   stateSetter = (state: ErrorHandlerState) => this.setState(state);
@@ -396,6 +396,7 @@ class ErrorHandler extends React.Component<{view: KanbanView}> {
         <div style={{ margin: "2em" }}>
           <h1>{t("Something went wrong")}</h1>
           <p>{error}</p>
+          <p>{t("You may wish to open as markdown and inspect or edit the file.")}</p>
           {stack && <pre>{stack}</pre>}
         </div>
       );

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -26,6 +26,8 @@ export default {
   Complete: "Complete",
   Archive: "Archive",
   "Invalid Kanban file: problems parsing frontmatter": "Invalid Kanban file: problems parsing frontmatter",
+  "I don't know how to interpret this line:": "I don't know how to interpret this line:",
+  Untitled: "Untitled", // auto-created column
 
   // settingHelpers.ts
   "Note: No template plugins are currently enabled.":

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -21,6 +21,7 @@ export default {
   "Open board settings": "Open board settings",
   "Archive completed cards": "Archive completed cards",
   "Something went wrong": "Something went wrong",
+  "You may wish to open as markdown and inspect or edit the file.": "You may wish to open as markdown and inspect or edit the file.",
 
   // parser.ts
   Complete: "Complete",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -470,7 +470,7 @@ export class KanbanParser {
               titleSearch: processed.titleSearch,
               titleRaw,
               data: {
-                isComplete: marker !== " ",
+                isComplete: marker && marker !== " ",
               },
               metadata: processed.metadata,
               dom: processed.dom

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,13 +19,13 @@ export const frontMatterKey = "kanban-plugin";
 const newLineRegex = /[\r\n]+/g;
 
 // Begins with one or more # followed by a space
-const laneRegex = /^#+\s+(.+)$/;
+const laneRegex = /^#+\s+(.*)$/;
 
 const itemRegex = new RegExp([
-  /^\s*/,               // leading whitespace
-  /[-+*]\s*/,           // bullet and its whitespace
-  /(?:\[([^\]])\]\s+)/, // task marker and whitespace (group 1)
-  /(.*)$/,              // Text (group 2)
+  /^\s*/,                // leading whitespace
+  /[-+*]\s*/,            // bullet and its whitespace
+  /(?:\[([^\]])\]\s+)?/, // task marker and whitespace (group 1)
+  /(.*)$/,               // Text (group 2)
 ].map(r => r.source).join(""));
 
 
@@ -406,7 +406,8 @@ export class KanbanParser {
     * Should internal link be resolved from DOM instead of regex?
     */
 
-    const [beforeFrontMatter, frontMatter, body] = boardMd.split(/^---\r?$\n?/m, 3);
+    const [beforeFrontMatter, frontMatter, ...bodyParts] = boardMd.split(/^---$/m);
+    const body = bodyParts.join("---");
 
     if (beforeFrontMatter.trim()) throw new Error(t("Invalid Kanban file: problems parsing frontmatter"));
 
@@ -542,6 +543,15 @@ export class KanbanParser {
         if (haveSeenArchiveMarker) {
           archive.push(item);
         } else {
+          if (!currentLane) {
+            // Auto-generate an empty column
+            currentLane = {
+              id: generateInstanceId(),
+              items: [],
+              title: t("Untitled"),
+              data: {},
+            }
+          }
           currentLane.items.push(item);
         }
         continue
@@ -573,6 +583,8 @@ export class KanbanParser {
         currentLane.data.shouldMarkItemsComplete = true;
         continue;
       }
+
+      if (line.trim()) throw new Error(t("I don't know how to interpret this line:") + "\n"+ line);
     };
 
     // Push the last lane


### PR DESCRIPTION
* split() issue (new from #199)
* Wasn't handling non-task items (new from #199)
* Error if no first lane header (pre-existing issue)
* Was silently discarding lines it didn't understand (pre-existing issue)
* Didn't support empty-titled headings (even though you could create them!)  (pre-existing issue)
* Error handler caused a blank display instead of showing an error message if loading a file failed on first parse (not sure how far back this one goes)
* Added text to error handler to suggest editing the file as a fix