### PR TITLE
Add Issueforms for easier Bug Reports and Feature Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: File a bug report
+labels: ['enhancement']
+title: "[Bug]: "
+body:
+- type: markdown
+  attributes:
+    value: "**Please make sure you are on the latest version.**"
+- type: textarea
+  id: what-happened
+  attributes:
+    label: Describe the bug
+    placeholder: The following error occurs when running command X when I have X enabled. 
+  validations:
+    required: true
+- type: textarea
+  id: logs
+  attributes:
+    label: Relevant errors (if available)
+    description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks. Open Obsidian's Developer Console by pressing CTRL + SHIFT + I
+    render: shell
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Steps to reproduce
+  validations:
+    required: true
+- type: textarea
+  id: expected
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen.
+- type: textarea
+  id: context
+  attributes:
+    label: Addition context
+    description: Add any other context about the problem here.
+- type: markdown
+  attributes:
+    value: "**If applicable, add Language and API here:**"
+- type: dropdown
+  id: version
+  attributes:
+    label: Operating system
+    description: Which OS are you using?
+    options:
+      - Windows
+      - Linux
+      - macOS
+      - iOS
+      - Android
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a new Feature for this Plugin
+labels: ['enhancement']
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Self Check
+        - Try searching existing [GitHub Issues](https://github.com/phibr0/obsidian-dictionary/issues) (open or closed) for similar issues.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe the feature
+      description: A clear description of what you want to have in this Plugin.
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Does this fix a problem? If so, specify.
+  - type: textarea
+    attributes:
+      label: Did you consider other alternatives?
+      description: If so, specify
+  - type: textarea
+    attributes:
+      label: Screenshots and recordings
+      description: |
+        If applicable, add screenshots or videos to help explain your problem. (You might edit them to show what you want, or just explain where the feature should go and any problems behind the existing behaviour!) (Videos should be as short as possible! Avoid watermarks too.)


### PR DESCRIPTION
I added Issueforms for both Bug Reports and Feature Requests. This will help a lot with Bug Reports, because Users know what you need to fix it. 

If you want to preview how they look, you can test it on the Dictionary Plugin Repo: https://github.com/phibr0/obsidian-dictionary/issues/new/choose