### PR TITLE
Fix cards getting overwritten (data loss) after no-change-edit after re-order

### DIFF
--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -125,7 +125,7 @@ export const ItemContent = React.memo(function ItemContent({
         return true;
       }
     },
-    [stateManager, editState]
+    [stateManager, editState, path]
   );
 
   const onEscape = React.useCallback(() => {


### PR DESCRIPTION
Given a list of four items:
1. start editing an item
2. cancel the editing
3. drag that item to a different position
4. start editing the item
5. don't change anything, but complete the edit by pressing enter

Expected behavior is that nothing changes, but pressing enter in step 5 overwrites the item in the original position of the re-ordered item.

![example-2](https://user-images.githubusercontent.com/2371343/139417458-21c8c030-1a54-49e6-9572-eeda557a28c2.gif)

This took a while to track down, since it occurred so infrequently. This pull request fixes the above behavior:

![example-4](https://user-images.githubusercontent.com/2371343/139418523-d4f0f75a-3dc4-4ee1-8065-4790b667b706.gif)
