### PR TITLE
Fix wikilink path parsing

### DIFF
--- a/src/helpers/renderMarkdown.ts
+++ b/src/helpers/renderMarkdown.ts
@@ -24,23 +24,20 @@ interface NormalizedPath {
 
 export function getNormalizedPath(path: string): NormalizedPath {
   const stripped = path.replace(noBreakSpace, ' ').normalize('NFC');
-  const splitOnHash = stripped.split('#');
 
-  if (splitOnHash.length === 1) {
-    const splitOnAlias = splitOnHash[0].split('|');
-
-    return {
-      root: splitOnAlias[0],
-      subpath: '',
-      alias: splitOnAlias[1] || '',
-    };
-  }
-
-  const splitOnAlias = splitOnHash[1].split('|');
-
+  // split on first occurance of '|'
+  // "root#subpath##subsubpath|alias with |# chars"
+  //             0            ^        1
+  const splitOnAlias = stripped.split(/\|(.*)/)
+  
+  // split on first occurance of '#' (in substring)
+  // "root#subpath##subsubpath"
+  //   0  ^        1
+  const splitOnHash = splitOnAlias[0].split(/#(.*)/);
+  
   return {
     root: splitOnHash[0],
-    subpath: '#' + splitOnAlias[0],
+    subpath: splitOnHash[1] ? '#' + splitOnHash[1] : '',
     alias: splitOnAlias[1] || '',
   };
 }


### PR DESCRIPTION
This fixes the underlying parsing problems of Issue #456 explained in https://github.com/mgmeyers/obsidian-kanban/issues/456#issuecomment-1027932480 by reordering the string splitting operations.

Before this change the order was '#' (subpath) first, then '|' (alias). This led to the following problem:

    Link:          [[TestCard|Hash # and Pipe | in alias]]
    splitOnHash:     └──────0─────┘^└────────1─────────┘
    splitOnAlias:                   └────0───┘^└───1───┘
    Result:          └────root────┘ └#subpath┘ └─alias─┘

Inverting the order results in the correct parsing:

    Link:          [[TestCard|Hash # and Pipe | in alias]]
    splitOnAlias:    └──0───┘^└───────────1────────────┘
    splitOnHash:     └──0───┘
    Result:          └─root─┘ └─────────alias──────────┘ with empty subpath

These cases are now caught, too:

    [[root|alias with multiple || chars]]
    [[root#subpath##subsubpath|alias]]

This case is not caught (anymore):

    [[rootwith|char#subpath|alias]]

But I don't think '|' is allowed in the path, is it? [("Wikilink spec")](https://en.wikipedia.org/wiki/Help:Wikitext#Wikilinks)
It would make it impossible to distinguish path and alias.
