### PR TITLE
Add Documentation for Generating Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Create markdown-backed Kanban boards in [Obsidian](https://obsidian.md/)
 - [Frontmatter limitations & gotchas](https://matthewmeye.rs/obsidian-kanban/FAQs/Frontmatter%20limitations%20&%20gotchas)
 - [Themes with enhanced Kanban support](https://matthewmeye.rs/obsidian-kanban/FAQs/Themes%20with%20enhanced%20Kanban%20support)
 
+## Contributing
+- [Contributing to the documentation](docs/README.md)
+
 ## Support
 
 If you find this plugin useful and would like to support its development, you can sponsor [me](https://github.com/mgmeyers) on Github, or buy me a coffee.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# Obsidian Kanban Documentation
+The documentation for this plugin (available at [http://matthewmeye.rs/obsidian-kanban/](http://matthewmeye.rs/obsidian-kanban/)) is generated using [MkDocs](https://www.mkdocs.org/getting-started/)
+
+## Contributing
+### Requirements
+The following are required on your system to build docs locally:
+- [Python 3.x](https://wiki.python.org/moin/BeginnersGuide/Download)
+- [Pip](https://pip.pypa.io/en/stable/installation/)
+- [Virtualenv](https://virtualenv.pypa.io/en/latest/installation.html)
+
+### Setting Up
+- `cd` into the `docs` directory
+  ```
+  cd docs/
+  ```
+- Create a new virtual environment. This allows isolation of the project's Python environment
+  ```
+  virtualenv venv
+  ```
+- Activate the virtual environment
+  ```
+  source venv/bin/activate
+  ```
+  Your terminal should change to the virtual environment
+- Install the project requirements from the `requirements.txt` file:
+  ```
+  pip install -r requirements.txt
+  ```
+- Start the `mkdocs` dev server
+  ```
+  mkdocs serve
+  ```
+  The server should start, allowing you to view the documentation on your `localhost` on (the default) port `8000`: http://127.0.0.1:8000
+  The project automatically rebuilds & reloads the site once changes are detected

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mdx-truly-sane-lists==1.2
+mkdocs==1.3.0
+mkdocs-material==8.2.9


### PR DESCRIPTION
- Link to “docs documentation” from main README
- Add requirements.txt for docs project

### Notes
- Only added base requirements to `requirements.txt` - let me know whether the full list is preferred over this
- Please provide guidance on the auto-generated files