### PR TITLE
fix note folder drop-down #535

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -961,6 +961,7 @@ button.kanban-plugin__cancel-action-button {
   border-color: var(--background-modifier-border);
   word-break: normal;
   max-height: 200px;
+  overflow: scroll;
 }
 
 .kanban-plugin__board-settings-modal


### PR DESCRIPTION
Fixes 535. (on my end, note template scrolls but the note folder dropdown does not. Obsidian 0.14.7 on macos, Kanban version 1.2.40)

Currently, the note folder dropdown does not scroll (see comment in #535), and so does not show all folders. Setting this css key should fix this issue.

Thanks!