### PR TITLE
Initial multi-window support for 0.15.x (Fix #552)

### DIFF
--- a/src/MetadataSettings.tsx
+++ b/src/MetadataSettings.tsx
@@ -259,7 +259,7 @@ function useKeyModifiers({
 const accepts = [DataTypes.MetadataSetting];
 
 function Overlay({ keys }: { keys: MetadataSetting[] }) {
-  return ReactDOM.createPortal(
+  return (
     <DragOverlay>
       {(entity, styles) => {
         const path = entity.getPath();
@@ -281,8 +281,7 @@ function Overlay({ keys }: { keys: MetadataSetting[] }) {
           </div>
         );
       }}
-    </DragOverlay>,
-    document.body
+    </DragOverlay>
   );
 }
 

--- a/src/components/Editor/autocomplete.ts
+++ b/src/components/Editor/autocomplete.ts
@@ -97,6 +97,7 @@ export function constructAutocomplete({
   const editor = new TextareaEditor(inputRef.current);
   const autocomplete = new Textcomplete(editor, configs, {
     dropdown: {
+      parent: inputRef.current.ownerDocument.body,
       maxCount: 96,
       className: `${c('autocomplete')} ${c('ignore-click-outside')}`,
       rotate: true,
@@ -213,6 +214,7 @@ export function constructAutocomplete({
     };
 
     inputRef.current.addEventListener('keydown', keydownHandler);
+    const document = inputRef.current.ownerDocument;
 
     editor.on('change', (e: CustomEvent) => {
       const beforeCursor = e.detail.beforeCursor as string;

--- a/src/components/Editor/datepicker.ts
+++ b/src/components/Editor/datepicker.ts
@@ -64,6 +64,7 @@ export function ensureDatePickerIsOnScreen(
 ) {
   const height = div.clientHeight;
   const width = div.clientWidth;
+  const window = div.ownerDocument.defaultView;
 
   if (position.top + height > window.innerHeight) {
     div.style.top = `${(position.clientTop || 0) - height}px`;

--- a/src/components/Editor/textcomplete/textcomplete-core/Dropdown.ts
+++ b/src/components/Editor/textcomplete/textcomplete-core/Dropdown.ts
@@ -38,6 +38,8 @@ export class Dropdown extends EventEmitter {
   private activeIndex: number | null = null;
 
   static create(option: DropdownOption): Dropdown {
+    const parent = option.parent || window.document.body;
+    const document = parent.ownerDocument;
     const ul = document.createElement('ul');
     ul.className = option.className || DEFAULT_DROPDOWN_CLASS_NAME;
     Object.assign(
@@ -49,7 +51,6 @@ export class Dropdown extends EventEmitter {
       },
       option.style
     );
-    const parent = option.parent || document.body;
     parent?.appendChild(ul);
     return new Dropdown(ul, option);
   }
@@ -202,6 +203,7 @@ export class Dropdown extends EventEmitter {
   }
 
   setOffset(cursorOffset: CursorOffset): this {
+    const document = this.el.ownerDocument;
     const doc = document.documentElement;
     if (doc) {
       const elementWidth = this.el.offsetWidth;
@@ -263,6 +265,7 @@ export class Dropdown extends EventEmitter {
   }
 
   private renderItems(): this {
+    const document = this.el.ownerDocument;
     const fragment = document.createDocumentFragment();
     for (const item of this.items) {
       fragment.appendChild(item.el);
@@ -282,6 +285,7 @@ export class Dropdown extends EventEmitter {
     type: 'header' | 'footer'
   ): this {
     const option = this.option[type];
+    const document = this.el.ownerDocument;
     const li = document.createElement('li');
     li.className = `textcomplete-${type}`;
     li.innerHTML =
@@ -309,6 +313,7 @@ class DropdownItem {
     this.activeClassName =
       this.props.activeClassName || DEFAULT_DROPDOWN_ITEM_ACTIVE_CLASS_NAME;
 
+    const document = dropdown.el.ownerDocument;
     const li = document.createElement('li');
     li.className = this.active ? this.activeClassName : this.className;
 

--- a/src/components/Editor/textcomplete/textcomplete-textarea/TextareaEditor.ts
+++ b/src/components/Editor/textcomplete/textcomplete-textarea/TextareaEditor.ts
@@ -49,6 +49,7 @@ export class TextareaEditor extends Editor {
     const top = elOffset.top - elScroll.top + cursorPosition.top + lineHeight;
     const left = elOffset.left - elScroll.left + cursorPosition.left;
     const clientTop = this.el.getBoundingClientRect().top;
+    const document = this.el.ownerDocument;
     if (this.el.dir !== 'rtl') {
       return { top, left, lineHeight, clientTop };
     } else {

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -23,6 +23,7 @@ function useDatePickers(item: Item) {
   return React.useMemo(() => {
     const onEditDate: React.MouseEventHandler = (e) => {
       constructDatePicker(
+        e.view as unknown as Window, // Preact uses real events, so this is safe
         stateManager,
         { x: e.clientX, y: e.clientY },
         constructMenuDatePickerOnChange({
@@ -38,6 +39,7 @@ function useDatePickers(item: Item) {
 
     const onEditTime: React.MouseEventHandler = (e) => {
       constructTimePicker(
+        e.view as unknown as Window, // Preact uses real events, so this is safe
         stateManager,
         { x: e.clientX, y: e.clientY },
         constructMenuTimePickerOnChange({

--- a/src/components/Item/helpers.ts
+++ b/src/components/Item/helpers.ts
@@ -21,11 +21,13 @@ import { c, escapeRegExpStr } from '../helpers';
 import { Item } from '../types';
 
 export function constructDatePicker(
+  window: Window,
   stateManager: StateManager,
   coordinates: { x: number; y: number },
   onChange: (dates: Date[]) => void,
   date?: Date
 ) {
+  const {document} = window;
   return document.body.createDiv(
     { cls: `${c('date-picker')} ${c('ignore-click-outside')}` },
     (div) => {
@@ -159,6 +161,7 @@ export function buildTimeArray(stateManager: StateManager) {
 }
 
 export function constructTimePicker(
+  window: Window,
   stateManager: StateManager,
   coordinates: { x: number; y: number },
   onSelect: (opt: string) => void,
@@ -168,6 +171,7 @@ export function constructTimePicker(
   const timeFormat = stateManager.getSetting('time-format');
   const selected = time?.format(timeFormat);
 
+  const {document} = window;
   document.body.createDiv(
     { cls: `${pickerClassName} ${c('ignore-click-outside')}` },
     (div) => {

--- a/src/dnd/components/DragOverlay.tsx
+++ b/src/dnd/components/DragOverlay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 
 import { DragEventData } from '../managers/DragManager';
 import { Coordinates, Entity, Hitbox } from '../types';
@@ -8,6 +9,13 @@ import { DndManagerContext } from './context';
 
 export interface DragOverlayProps {
   children(entity: Entity, styles: React.CSSProperties): JSX.Element;
+}
+
+declare global {
+  interface Window {
+    // backward compatibility w/0.14.x; this block can be removed once we depend on 0.15.x API
+    activeDocument?: Document
+  }
 }
 
 function getDragOverlayStyles(
@@ -143,7 +151,7 @@ export function DragOverlay({ children }: DragOverlayProps) {
     return null;
   }
 
-  return children(dragEntity, styles);
+  return createPortal(children(dragEntity, styles), (window.activeDocument || document).body);
 }
 
 export function useIsAnythingDragging() {

--- a/src/dnd/managers/DragManager.ts
+++ b/src/dnd/managers/DragManager.ts
@@ -389,6 +389,8 @@ export function useDragHandle(
       return;
     }
 
+    const window = handle.ownerDocument.defaultView;
+
     const onPointerDown = (e: PointerEvent) => {
       if (e.defaultPrevented || (e.target as HTMLElement).dataset.ignoreDrag) {
         return;


### PR DESCRIPTION
This is just making it so that drag-drop works in all windows (but not between windows).  It doesn't address the ctrl-key handlers for checkboxes, or the shift key handler for drops: these only work in the main window at the moment.

To handle them properly, the ItemCheckbox would need to know what window it's in, and the main plugin would need to add shift-tracking handlers to all created windows (e.g. using a PerWindowComponent, as used in Quick Explorer and Hover Editor), or find some other way to get hold of the shift state.

The approach I've taken here is fairly minimalist: making DragOverlay always portal its children to the document.body of the active document.  This makes the assumption that if you're dragging, then the document containing the draggable should've been active.  A more "pure" approach would have the drag overlay figure out from the drag entity what document is applicable, but that would be a bit harder, as would refactoring to e.g. give each window its own drag manager or what-have-you.  So this quick-and-dirty approach works fine for what it does.

The other advantage of this approach is that it's easy to verify that in single-window (and pre-0.15.x) scenarios the behavior should be what it was before.  So this version could in principle be sent out as an update for 0.15.x users without breaking 0.14.x, even if the ctrl and shift keyboard handlers have to wait for a subsequent release.