### PR TITLE
Configurable display tag colors

### DIFF
--- a/src/TagColorSettings.tsx
+++ b/src/TagColorSettings.tsx
@@ -17,7 +17,6 @@ interface ItemProps {
 }
 
 function Item({ tagColorKey, deleteKey, updateKey }: ItemProps) {
-  console.log(tagColorKey);
   return (
     <div className={c('setting-item-wrapper')}>
       <div className={c('setting-item')}>

--- a/src/TagColorSettings.tsx
+++ b/src/TagColorSettings.tsx
@@ -1,0 +1,161 @@
+import Preact from 'preact/compat';
+import update from 'immutability-helper';
+import { c, generateInstanceId } from './components/helpers';
+import {
+  TagColorKey,
+  TagColorSetting,
+  TagColorSettingTemplate,
+} from './components/types';
+import { getParentBodyElement } from './dnd/util/getWindow';
+import { t } from './lang/helpers';
+import { Icon } from './components/Icon/Icon';
+
+interface ItemProps {
+  tagColorKey: TagColorKey;
+  deleteKey: () => void;
+  updateKey: (tagKey: string, color: string) => void;
+}
+
+function Item({ tagColorKey, deleteKey, updateKey }: ItemProps) {
+  console.log(tagColorKey);
+  return (
+    <div className={c('setting-item-wrapper')}>
+      <div className={c('setting-item')}>
+        <div className={c('tag-color-input')}>
+          <input
+            type="text"
+            placeholder="#tag"
+            value={tagColorKey.tagKey}
+            onChange={(e) => {
+              updateKey(e.currentTarget.value, tagColorKey.color);
+            }}
+          />
+          <input
+            type="text"
+            placeholder="#ffffff"
+            value={tagColorKey.color}
+            onChange={(e) => {
+              updateKey(tagColorKey.tagKey, e.currentTarget.value);
+            }}
+          />
+          <div
+            style={{
+              height: '16px',
+              width: '16px',
+              backgroundColor: tagColorKey.color,
+              border: '1px solid black',
+            }}
+          />
+        </div>
+        <div className={c('setting-button-wrapper')}>
+          <div onClick={deleteKey} aria-label={t('Delete')}>
+            <Icon name="cross" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TagSettingsProps {
+  dataKeys: TagColorSetting[];
+  onChange: (settings: TagColorSetting[]) => void;
+  portalContainer: HTMLElement;
+}
+
+function TagSettings({ dataKeys, onChange }: TagSettingsProps) {
+  const [keys, setKeys] = Preact.useState(dataKeys);
+
+  const updateKeys = (keys: TagColorSetting[]) => {
+    onChange(keys);
+    setKeys(keys);
+  };
+
+  const newKey = () => {
+    updateKeys(
+      update(keys, {
+        $push: [
+          {
+            ...TagColorSettingTemplate,
+            id: generateInstanceId(),
+            data: {
+              tagKey: '',
+              color: '',
+            },
+          },
+        ],
+      })
+    );
+  };
+
+  const deleteKey = (i: number) => {
+    updateKeys(
+      update(keys, {
+        $splice: [[i, 1]],
+      })
+    );
+  };
+
+  const updateTagColor = (i: number) => (tagKey: string, color: string) => {
+    updateKeys(
+      update(keys, {
+        [i]: {
+          data: {
+            tagKey: {
+              $set: tagKey,
+            },
+            color: {
+              $set: color,
+            },
+          },
+        },
+      })
+    );
+  };
+
+  return (
+    <div className={c('tag-color-input-wrapper')}>
+      <div className="setting-item-info">
+        <div className="setting-item-name">{t('Display tag colors')}</div>
+        <div className="setting-item-description">
+          {t('Set colors for the tags displayed below the card title.')}
+        </div>
+      </div>
+      {keys.map((key, index) => (
+        <Item
+          key={key.id}
+          tagColorKey={key.data}
+          deleteKey={() => deleteKey(index)}
+          updateKey={updateTagColor(index)}
+        />
+      ))}
+      <button
+        className={c('add-tag-color-button')}
+        onClick={() => {
+          newKey();
+        }}
+      >
+        {t('Add tag color')}
+      </button>
+    </div>
+  );
+}
+
+export function renderTagSettings(
+  containerEl: HTMLElement,
+  keys: TagColorSetting[],
+  onChange: (key: TagColorSetting[]) => void
+) {
+  Preact.render(
+    <TagSettings
+      dataKeys={keys}
+      onChange={onChange}
+      portalContainer={getParentBodyElement(containerEl)}
+    />,
+    containerEl
+  );
+}
+
+export function cleanUpTagSettings(containerEl: HTMLElement) {
+  Preact.unmountComponentAtNode(containerEl);
+}

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -2,6 +2,7 @@ import { TFile } from 'obsidian';
 import Preact from 'preact/compat';
 
 import { useNestedEntityPath } from 'src/dnd/components/Droppable';
+import { StateManager } from 'src/StateManager';
 
 import { KanbanContext } from '../context';
 import { handlePaste } from '../Editor/helpers';
@@ -59,6 +60,21 @@ function useDatePickers(item: Item) {
       onEditTime,
     };
   }, [boardModifiers, path, item, stateManager]);
+}
+
+function useTagColors(stateManager: StateManager): { [tag: string]: string } {
+  const tagColors = stateManager.useSetting('tag-colors');
+
+  return (tagColors || []).reduce((total, current) => {
+    if (!current.tagKey || !current.color) {
+      return total;
+    }
+
+    return {
+      ...total,
+      [current.tagKey]: current.color,
+    };
+  }, {});
 }
 
 export interface ItemContentProps {
@@ -130,6 +146,9 @@ export const ItemContent = Preact.memo(function ItemContent({
     Preact.useContext(KanbanContext);
 
   const hideTagsDisplay = stateManager.useSetting('hide-tags-display');
+
+  const tagColorMap = useTagColors(stateManager);
+
   const path = useNestedEntityPath();
 
   const { onEditDate, onEditTime } = useDatePickers(item);
@@ -259,6 +278,12 @@ export const ItemContent = Preact.memo(function ItemContent({
                       ? 'is-search-match'
                       : ''
                   }`}
+                  style={
+                    !!tagColorMap[tag] && {
+                      backgroundColor: tagColorMap[tag],
+                      color: 'white',
+                    }
+                  }
                 >
                   <span>{tag[0]}</span>
                   {tag.slice(1)}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -27,6 +27,11 @@ export interface DataKey {
   containsMarkdown: boolean;
 }
 
+export interface TagColorKey {
+  tagKey: string;
+  color: string;
+}
+
 export type PageDataValue =
   | string
   | number
@@ -81,12 +86,14 @@ export type Item = Nestable<ItemData>;
 export type Lane = Nestable<LaneData, Item>;
 export type Board = Nestable<BoardData, Lane>;
 export type MetadataSetting = Nestable<DataKey>;
+export type TagColorSetting = Nestable<TagColorKey>;
 
 export const DataTypes = {
   Item: 'item',
   Lane: 'lane',
   Board: 'board',
   MetadataSetting: 'metadata-setting',
+  TagColorSetting: 'tag-color',
 };
 
 export const ItemTemplate = {
@@ -108,5 +115,11 @@ export const BoardTemplate = {
 export const MetadataSettingTemplate = {
   accepts: [DataTypes.MetadataSetting],
   type: DataTypes.MetadataSetting,
+  children: [] as any[],
+};
+
+export const TagColorSettingTemplate = {
+  accepts: [] as string[],
+  type: DataTypes.TagColorSetting,
   children: [] as any[],
 };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -121,6 +121,9 @@ export default {
   'Hide card display tags': 'Hide card display tags',
   'When toggled, tags will not be displayed below the card title.':
     'When toggled, tags will not be displayed below the card title.',
+  'Display tag colors': 'Display tag colors',
+  'Set colors for the tags displayed below the card title.':
+    'Set colors for the tags displayed below the card title.',
   'Linked Page Metadata': 'Linked Page Metadata',
   'Display metadata for the first note linked within a card. Specify which metadata keys to display below. An optional label can be provided, and labels can be hidden altogether.':
     'Display metadata for the first note linked within a card. Specify which metadata keys to display below. An optional label can be provided, and labels can be hidden altogether.',
@@ -144,6 +147,9 @@ export default {
   Delete: 'Delete',
   'Add key': 'Add key',
   'Field contains markdown': 'Field contains markdown',
+
+  // TagColorSettings.tsx
+  'Add tag color': 'Add tag color',
 
   // components/Item/Item.tsx
   'More options': 'More options',
@@ -177,6 +183,7 @@ export default {
   'Copy link to card': 'Copy link to card',
   'Insert card before': 'Insert card before',
   'Insert card after': 'Insert card after',
+  'Add label': 'Add label',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Enter list title...',

--- a/src/main.css
+++ b/src/main.css
@@ -1334,6 +1334,25 @@ button.kanban-plugin__cancel-action-button {
   margin-right: 10px;
 }
 
+.kanban-plugin__tag-color-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 1rem;
+}
+
+.kanban-plugin__add-tag-color-button {
+  align-self: baseline;
+  margin: 0;
+}
+
+.kanban-plugin__tag-color-input {
+  gap: 1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .kanban-plugin__metadata-setting-desc {
   font-size: 14px;
 }


### PR DESCRIPTION
This PR adds the ability to configure colors for display tags, replicating Trello's label functionality.

### Demo
![display tag colors](https://user-images.githubusercontent.com/4622925/190037905-da4b667f-5561-4c16-b083-e2840d391486.png)

### Settings
![settings](https://user-images.githubusercontent.com/4622925/190038585-ab31d985-6408-4813-9569-c8aafc820263.png)


I'm opening this mostly to get a conversation started. I would love to get your thoughts on this feature. I [asked the Obsidian MD subreddit](https://www.reddit.com/r/ObsidianMD/comments/xcdkn1/would_anyone_be_interested_in_colorful_tags_for/) if this is a feature that would be desired, and the response seemed overwhelmingly positive. The implementation and configurability is still something I'm not certain about.

Here are my main questions:
- Is this a feature you'd want to integrate directly into this plugin?
- Does this implementation make sense to you? I wondered if I should use the existing tag functionality or create a totally new concept like labels. Tags seemed to make more sense to me (and was less work to implement).
- Are the settings for this feature sufficient? Should there be any additional configuration options?

Of course, any other feedback you might have about what I've done here is greatly appreciated as well!
