### PR TITLE
Implement move-to-top and move-to-bottom item operations.

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -199,6 +199,16 @@ export function useItemMenu({
               });
           })
           .addItem((i) => {
+            i.setIcon('up-arrow-with-tail')
+              .setTitle(t('Move to top'))
+              .onClick(async () => boardModifiers.moveItemToTop(path));
+          })
+          .addItem((i) => {
+            i.setIcon('down-arrow-with-tail')
+              .setTitle(t('Move to bottom'))
+              .onClick(async () => boardModifiers.moveItemToBottom(path));
+          })
+          .addItem((i) => {
             i.setIcon('sheets-in-box')
               .setTitle(t('Archive card'))
               .onClick(() => boardModifiers.archiveItem(path));

--- a/src/helpers/boardModifiers.ts
+++ b/src/helpers/boardModifiers.ts
@@ -6,6 +6,7 @@ import {
   appendEntities,
   getEntityFromPath,
   insertEntity,
+  moveEntity,
   prependEntities,
   removeEntity,
   updateEntity,
@@ -21,6 +22,8 @@ export interface BoardModifiers {
   prependItems: (path: Path, items: Item[]) => void;
   insertItems: (path: Path, items: Item[]) => void;
   splitItem: (path: Path, items: Item[]) => void;
+  moveItemToTop: (path: Path) => void;
+  moveItemToBottom: (path: Path) => void;
   addLane: (lane: Lane) => void;
   insertLane: (path: Path, lane: Lane) => void;
   updateLane: (path: Path, lane: Lane) => void;
@@ -102,6 +105,20 @@ export function getBoardModifiers(stateManager: StateManager): BoardModifiers {
 
       stateManager.setState((boardData) => {
         return insertEntity(removeEntity(boardData, path), path, items);
+      });
+    },
+
+    moveItemToTop: (path: Path) => {
+      stateManager.setState((boardData) =>
+        moveEntity(boardData, path, [path[0], 0])
+      );
+    },
+
+    moveItemToBottom: (path: Path) => {
+      stateManager.setState((boardData) => {
+        const laneIndex = path[0];
+        const lane = boardData.children[laneIndex];
+        return moveEntity(boardData, path, [laneIndex, lane.children.length]);
       });
     },
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -187,6 +187,8 @@ export default {
   'Insert card before': 'Insert card before',
   'Insert card after': 'Insert card after',
   'Add label': 'Add label',
+  'Move to top': 'Move to top',
+  'Move to bottom': 'Move to bottom',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Enter list title...',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -175,6 +175,8 @@ export default {
   'Copy link to card': '复制链接至卡片',
   'Insert card before': '在上方插入卡片',
   'Insert card after': '在下方插入卡片',
+  'Move to top': '移到顶部',
+  'Move to bottom': '移至底部',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': '输入新的列标题……',


### PR DESCRIPTION
Implements the idea proposed in #510 which involves adding 2 new operations in the card's context menu: 
- 'Move to top' moves the card to the top of the lane.
- 'Move to bottom' moves the card to the bottom of the lane.

**Demo**:

https://user-images.githubusercontent.com/54927071/191432600-baea0c05-7ae0-4944-af03-35e4191f41fa.mp4


