### PR TITLE
Colored relative dates (based on @jacobaclarke's PR)

### DIFF
--- a/src/components/Item/DateAndTime.tsx
+++ b/src/components/Item/DateAndTime.tsx
@@ -55,17 +55,15 @@ export function RelativeDate({ item, stateManager }: DateProps) {
 
   // Only make changes if item is incomplete and due within the next week
   if (needsColoring) {
-    if (diff >= 4) {
-      // Between 7 - 5 days
-      className += 'upcoming';
-    } else if (diff >= 2) {
-      // Between 5 - 3 days
-      className += 'soon';
-    } else if (diff >= 0) {
-      // Between 3 - 1 days
+    if (diff == 0) {
+      // Within the next day
       className += 'today';
+    } else if (diff <= 2) {
+      // Within the next 3 days
+      className += 'soon';
     } else {
-      className += 'overdue';
+      // Within the next week
+      className += 'upcoming';
     }
   }
 

--- a/src/components/Item/DateAndTime.tsx
+++ b/src/components/Item/DateAndTime.tsx
@@ -48,28 +48,32 @@ export function RelativeDate({ item, stateManager }: DateProps) {
     item.data.metadata.time
   );
 
-  let className = "item-metadata-date-relative-";
+  // Gather info for coloring
+  let className = 'item-metadata-date-relative-';
   const diff = item.data.metadata.date.diff(moment(), 'day');
   const needsColoring = !item.data.isComplete && diff <= 6;
+
   // Only make changes if item is incomplete and due within the next week
   if (needsColoring) {
     if (diff >= 4) {
       // Between 7 - 5 days
-      className += "upcoming";
+      className += 'upcoming';
     } else if (diff >= 2) {
       // Between 5 - 3 days
-      className += "soon";
+      className += 'soon';
     } else if (diff >= 0) {
       // Between 3 - 1 days
-      className += "today";
+      className += 'today';
     } else {
-      className += "overdue";
+      className += 'overdue';
     }
   }
 
   return (
     <span
-      className={`${c('item-metadata-date-relative')} ${needsColoring && c(className)}`}
+      className={`${c('item-metadata-date-relative')} ${
+        needsColoring && c(className)
+      }`}
     >
       {relativeDate}
     </span>

--- a/src/components/Item/DateAndTime.tsx
+++ b/src/components/Item/DateAndTime.tsx
@@ -48,16 +48,28 @@ export function RelativeDate({ item, stateManager }: DateProps) {
     item.data.metadata.time
   );
 
+  let className = "item-metadata-date-relative-";
+  const diff = item.data.metadata.date.diff(moment(), 'day');
+  const needsColoring = !item.data.isComplete && diff <= 6;
+  // Only make changes if item is incomplete and due within the next week
+  if (needsColoring) {
+    if (diff >= 4) {
+      // Between 7 - 5 days
+      className += "upcoming";
+    } else if (diff >= 2) {
+      // Between 5 - 3 days
+      className += "soon";
+    } else if (diff >= 0) {
+      // Between 3 - 1 days
+      className += "today";
+    } else {
+      className += "overdue";
+    }
+  }
+
   return (
     <span
-      className={`${c('item-metadata-date-relative')} ${
-        (relativeDate.includes('ago') || relativeDate.includes('yesterday')) &&
-        c('item-metadata-date-relative-passed')
-      } ${
-        relativeDate.includes('in') && c('item-metadata-date-relative-future')
-      } ${
-        relativeDate.includes('oday') && c('item-metadata-date-relative-today')
-      }`}
+      className={`${c('item-metadata-date-relative')} ${needsColoring && c(className)}`}
     >
       {relativeDate}
     </span>

--- a/src/main.css
+++ b/src/main.css
@@ -532,15 +532,22 @@ button.kanban-plugin__new-item-button {
 }
 
 .kanban-plugin__item-metadata-date-relative-soon {
-  color: orange
+  color: orange;
 }
 
 .kanban-plugin__item-metadata-date-relative-today {
   color: red;
+  font-weight: bold;
 }
 
-.kanban-plugin__item-metadata-date-relative-overdue {
+.kanban-plugin__item.is-past:not(.is-complete) .kanban-plugin__item-metadata-date-relative {
   color: magenta;
+  font-weight: bold;
+  font-style: italic;
+}
+
+.kanban-plugin__item.is-complete .kanban-plugin__item-markdown {
+  text-decoration: line-through;
 }
 
 .kanban-plugin__item-metadata a {

--- a/src/main.css
+++ b/src/main.css
@@ -526,16 +526,21 @@ button.kanban-plugin__new-item-button {
   text-transform: uppercase;
 }
 
-.kanban-plugin__item-metadata-date-relative-passed {
-  color: red;
+
+.kanban-plugin__item-metadata-date-relative-upcoming {
+  color: green;
 }
 
-.kanban-plugin__item-metadata-date-relative-future {
-  color: blue;
+.kanban-plugin__item-metadata-date-relative-soon {
+  color: orange
 }
 
 .kanban-plugin__item-metadata-date-relative-today {
-  color: green;
+  color: red;
+}
+
+.kanban-plugin__item-metadata-date-relative-overdue {
+  color: magenta;
 }
 
 .kanban-plugin__item-metadata a {


### PR DESCRIPTION
**This is an extension of the work @jacobaclarke did in #634 . Credit to Jacob for getting this started.**

**Changes:**
- Give colors to relative dates based on how close they are to their due dates
- Splits colors into more controllable categories (based on the `diff` or number of days until or after the due date)
- Removes colors after an item is completed
- Refactored coloring logic from #634 into an if statement to be cleaner and more flexible
- Changed colors chosen to be readable in light/dark modes

**Future:**
- Category ranges can be exposed as settings. I don't know how to interface with settings, but if somebody does this will be an easy addition.
- Colors could also be made customizable in settings as well.
- Add custom/more categories?