### PR TITLE
Attempted feature implementation: sort lane by tags

### DIFF
--- a/src/components/Lane/LaneMenu.tsx
+++ b/src/components/Lane/LaneMenu.tsx
@@ -171,6 +171,52 @@ export function useSettingsMenu({
             );
           });
       })
+      .addItem((item) => {
+        item
+          .setIcon('lucide-move-vertical')
+          .setTitle(t('Sort by tags'))
+          .onClick(() => {
+            const children = lane.children.slice();
+            const isAsc = lane.data.sorted === LaneSort.TagsAsc;
+
+            //`Sort` children by the item's tags
+            //I wish I was using ruby right now
+            children.sort((a, b) => {
+              //Join tags into a string
+              const tagsA = a.data.metadata.tags.join(' ');
+              const tagsB = b.data.metadata.tags.join(' ');
+
+              //Compare the strings, using isAsc to determine the order
+              if (tagsA > tagsB) {
+                return isAsc ? 1 : -1;
+              }
+
+              if (tagsA < tagsB) {
+                return isAsc ? -1 : 1;
+              }
+
+              //If they are the same, return 0
+              return 0;
+            });
+
+            boardModifiers.updateLane(
+              path,
+              update(lane, {
+                children: {
+                  $set: children,
+                },
+                data: {
+                  sorted: {
+                    $set:
+                      lane.data.sorted === LaneSort.TagsAsc
+                        ? LaneSort.TagsDsc
+                        : LaneSort.TagsAsc,
+                  },
+                },
+              })
+            );
+          });
+      })
       .addSeparator()
       .addItem((i) => {
         i.setIcon('corner-left-down')

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -9,6 +9,8 @@ export enum LaneSort {
   TitleDsc,
   DateAsc,
   DateDsc,
+  TagsAsc,
+  TagsDsc,
 }
 
 export interface LaneData {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -231,6 +231,7 @@ export default {
   'Insert list after': 'Insert list after',
   'Sort by card text': 'Sort by card text',
   'Sort by date': 'Sort by date',
+  'Sort by tags': 'Sort by tags',
 
   // components/helpers/renderMarkdown.ts
   'Unable to find': 'Unable to find',


### PR DESCRIPTION
A feature I was missing was the ability to group notes by their tags, so I wrote a sketch implementation of that feature. Perhaps I should have opened an issue for a feature request?...

My ideal implementation would be to do a groupBy tags and then flatten the array, but Array.groupBy is currently not quite in the ES standard. I didn't want to use Lodash as not to bring in another (large) library. Instead, I had to make do by performing a sort on the tags. This will, in theory, visually keep notes with the same tags together, although there isn't a huge amount of control you have over the process.

Should you decide to pull this, please test this and provide any feedback before doing so. TS/JS is not my domain by any means and so I have no idea how to test this feature, and there is a solid chance I made a mistake somewhere.