### PR TITLE
Added seconds to the hydrateBoard.ts Fix #197

### DIFF
--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -61,6 +61,7 @@ export async function hydrateItem(stateManager: StateManager, item: Item) {
 
       date.hour(time.hour());
       date.minute(time.minute());
+      date.second(time.second());
 
       time = date.clone();
     }


### PR DESCRIPTION
This line fixes this issue. The seconds store in the file were not being passed into the hydrateBoard.ts, now they are!