### PR TITLE
[WIP] Change table to definition list in MetadataTable

### DIFF
--- a/src/components/Item/MetadataTable.tsx
+++ b/src/components/Item/MetadataTable.tsx
@@ -142,58 +142,56 @@ export const MetadataTable = Preact.memo(function MetadataTable({
   if (!metadata || !order || order.length === 0) return null;
 
   return (
-    <table className={c('meta-table')}>
-      <tbody>
-        {order.map((k) => {
-          const data = metadata[k];
-          return (
-            <tr key={k} className={c('meta-row')}>
-              {!data.shouldHideLabel && (
-                <td
-                  className={`${c('meta-key')} ${
-                    (data.label || k).toLocaleLowerCase().contains(searchQuery)
-                      ? 'is-search-match'
-                      : ''
-                  }`}
-                  data-key={k}
-                >
-                  <span>{data.label || k}</span>
-                </td>
-              )}
-              <td
-                colSpan={data.shouldHideLabel ? 2 : 1}
-                className={c('meta-value-wrapper')}
-                data-value={
-                  Array.isArray(data.value)
-                    ? data.value.join(', ')
-                    : `${data.value}`
-                }
+    <dl className={c('meta-table')}>
+      {order.map((k) => {
+        const data = metadata[k];
+        return (
+          <Preact.Fragment key={k}>
+            {!data.shouldHideLabel && (
+              <dt
+                className={`${c('meta-key')} ${
+                  (data.label || k).toLocaleLowerCase().contains(searchQuery)
+                    ? 'is-search-match'
+                    : ''
+                }`}
+                data-key={k}
               >
-                {k === 'tags' ? (
-                  (data.value as string[]).map((tag, i) => {
-                    return (
-                      <a
-                        href={tag}
-                        key={i}
-                        className={`tag ${c('item-tag')} ${
-                          tag.toLocaleLowerCase().contains(searchQuery)
-                            ? 'is-search-match'
-                            : ''
-                        }`}
-                      >
-                        <span>{tag[0]}</span>
-                        {tag.slice(1)}
-                      </a>
-                    );
-                  })
-                ) : (
-                  <MetadataValue data={data} searchQuery={searchQuery} />
-                )}
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+                <span>{data.label || k}</span>
+              </dt>
+          )}
+          <dd
+            colSpan={data.shouldHideLabel ? 2 : 1}
+            className={c('meta-value-wrapper')}
+            data-value={
+              Array.isArray(data.value)
+              ? data.value.join(', ')
+              : `${data.value}`
+            }
+          >
+            {k === 'tags' ? (
+              (data.value as string[]).map((tag, i) => {
+                return (
+                  <a
+                    href={tag}
+                    key={i}
+                    className={`tag ${c('item-tag')} ${
+                      tag.toLocaleLowerCase().contains(searchQuery)
+                        ? 'is-search-match'
+                        : ''
+                    }`}
+                  >
+                    <span>{tag[0]}</span>
+                  {tag.slice(1)}
+                </a>
+              );
+              })
+            ) : (
+              <MetadataValue data={data} searchQuery={searchQuery} />
+            )}
+          </dd>
+          </Preact.Fragment>
+        );
+      })}
+    </dl>
   );
 });


### PR DESCRIPTION
This PR is a "proposal in code" that illustrates switching MetadataTable to use definition lists rather than tables. The current form is deliberately minimal to make absolutely clear what I'm proposing, but I wouldn't consider it complete. See below for possible additional work.

The benefits of using `<dl>` versus `<table>` include:
- Description lists' default styling works better in a narrow column like Kanban's lists. See screenshots below
- Can be styled exactly like table for backward compatibility
- Allows obsidian-kanban, themes, and user custom styles greater flexibility in changing the presentation of MetadataTable

Motivating use case: When I discovered this feature, I was already using Kanban for project notes with a `Complete when::` metadata tag. But the use of tables forces a side-by-side presentation of each key/value pair, which was visually awkward for long keys (like this one) AND for long value text.

Here's a "before" image of the current codebase (v1.5.2) using `<table>`:
<img width="1008" alt="Screenshot 2023-04-29 at 11 33 16 AM" src="https://user-images.githubusercontent.com/44155/235319126-6e35e1f6-376e-4571-886e-4a86bc8cce83.png">

For comparison, here's how it looks with `<dl>`, but zero styling work:
<img width="1008" alt="Screenshot 2023-04-29 at 11 33 18 AM" src="https://user-images.githubusercontent.com/44155/235319169-f6ae63ec-62f0-44be-a464-f51fe1ac7c57.png">

If this seems like a good direction, likely next steps are:
- Fix the key styling, as the key's `color: var(--text-muted)` styling was dropped
- If strong backward compatibility is desired, restyle the description list to match the existing table
- (OPTIONAL) Add a simple switch to toggle between table-style (side by side) and dl-style (over-under) presentation
- (OPTIONAL) Add a style selector to let the user choose between multiple out-of-the-box styles
- Optimize the dl-style presentation specifically for Kanban's lists

Does this seem like a desirable approach?  If so, what changes would you like to land this plugin?