### PR TITLE
Fixes scrolling on touch-enabled devices (#702)

### DIFF
--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -314,7 +314,11 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
               },
             ])}
             onMouseOver={onMouseOver}
-            onPointerDown={onClick}
+            onDragStart={(e: DragEvent) => {
+              const targetEl = e.target as HTMLElement;
+              if (targetEl.tagName !== 'A') return;
+              e.preventDefault();
+            }}
             onClick={onClick}
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore


### PR DESCRIPTION
Pointerdown events fire as soon as user touches the screen in order to initiate swipe gesture. If its default action isn't prevented, click event will anyway fire, so adding the same event listener to pointerdown event is redundant. So we remove it.

On the other hand, not suppressing pointerdown event allows dragstart events to fire on anchor nodes, which triggers browser's default action that is probably not what user have wanted (because this has never worked before), so we prevent via `preventDefault()` call.

This allows one to swipe normally and move cards around by dnd while touching anchor nodes.