### PR TITLE
add tasks completion bar

### DIFF
--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -236,8 +236,15 @@ export const ItemContent = Preact.memo(function ItemContent({
     );
   }
 
+  const { completed, incomplete } = item.data.metadata.tasks
+
   return (
     <div className={c('item-title')}>
+      {(!!completed || !!incomplete) && (
+        <div className={c("task-progress")}>
+          <div className={c("task-progress-bar")} style={{ "--progress-width": (completed / (completed + incomplete)) * 100 + "%" }}></div>
+        </div>
+      )}
       <MarkdownDomRenderer
         className={c('item-markdown')}
         dom={item.data.dom}
@@ -263,11 +270,10 @@ export const ItemContent = Preact.memo(function ItemContent({
                 <a
                   href={tag}
                   key={i}
-                  className={`tag ${c('item-tag')} ${
-                    tag.toLocaleLowerCase().contains(searchQuery)
-                      ? 'is-search-match'
-                      : ''
-                  }`}
+                  className={`tag ${c('item-tag')} ${tag.toLocaleLowerCase().contains(searchQuery)
+                    ? 'is-search-match'
+                    : ''
+                    }`}
                   style={
                     tagColor && {
                       '--tag-color': tagColor.color,

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -68,6 +68,10 @@ export interface ItemMetaData {
   file?: TFile | null;
   fileMetadata?: FileMetadata;
   fileMetadataOrder?: string[];
+  tasks?: {
+    completed?: number;
+    incomplete?: number;
+  };
 }
 
 export interface ItemData {

--- a/src/main.less
+++ b/src/main.less
@@ -1535,3 +1535,16 @@ body:not(.native-scrollbars)
   left: 0;
   transform: translate(0, -100%);
 }
+
+.kanban-plugin__task-progress > *,
+.kanban-plugin__task-progress {
+  height: 6px;
+  border-radius: 10px;
+  background-color: var(--background-secondary);
+}
+
+.kanban-plugin__task-progress > * {
+  background-color: var(--color-accent);
+  width: var(--progress-width);
+  transition: 400ms ease-out;
+}

--- a/src/parsers/formats/list.ts
+++ b/src/parsers/formats/list.ts
@@ -71,6 +71,10 @@ export function listItemToItemData(
       file: undefined,
       fileMetadata: undefined,
       fileMetadataOrder: undefined,
+      tasks: {
+        completed: 0,
+        incomplete: 0,
+      },
     },
     dom: undefined,
     isComplete: !!item.checked,
@@ -160,6 +164,10 @@ export function listItemToItemData(
   );
 
   itemData.title = replaceBrs(executeDeletion(title));
+
+  itemData.metadata.tasks.completed = itemData.titleRaw.split('[x]').length - 1;
+  itemData.metadata.tasks.incomplete =
+    itemData.titleRaw.split('[ ]').length - 1;
 
   return itemData;
 }


### PR DESCRIPTION
[tasks.webm](https://github.com/mgmeyers/obsidian-kanban/assets/72335827/3eae21a2-368a-4506-af75-c12f21badf21)

adds #781

@mgmeyers i got this working with titles but i also want to make it work with a 'linked' card and then maybe show the task counts and completed tasks can you help with that?

also please let me know a better way to detect the check-marks i don't think this isn't the best way