### PR TITLE
Feature: hide cards on search

### DIFF
--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -194,7 +194,6 @@ export class KanbanView extends TextFileView implements HoverParent {
     ).open();
   }
 
-
   onPaneMenu(menu: Menu, source: string, callSuper: boolean = true) {
     if (source !== 'more-options') {
       super.onPaneMenu(menu, source);

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -193,7 +193,6 @@ export class KanbanView extends TextFileView implements HoverParent {
       board.data.settings
     ).open();
   }
-
   onPaneMenu(menu: Menu, source: string, callSuper: boolean = true) {
     if (source !== 'more-options') {
       super.onPaneMenu(menu, source);

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -86,6 +86,7 @@ export interface KanbanSettings {
   'show-view-as-markdown'?: boolean;
   'show-board-settings'?: boolean;
   'show-search'?: boolean;
+  'cards-behavior-on-search'?: 'highlight' | 'hide';
 
   'tag-colors'?: TagColorKey[];
   'date-colors'?: DateColorKey[];
@@ -126,6 +127,7 @@ export const settingKeyLookup: Record<keyof KanbanSettings, true> = {
   'show-search': true,
   'tag-colors': true,
   'date-colors': true,
+  'cards-behavior-on-search': true,
 };
 
 export type SettingRetriever = <K extends keyof KanbanSettings>(
@@ -554,6 +556,31 @@ export class SettingsManager {
                 });
               });
           });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Cards behavior on search'))
+      .then((setting) => {
+        setting.addDropdown((dropdown) => {
+          dropdown.addOption('highlight', t('Highlight relevant'));
+          dropdown.addOption('hide', t('Hide irrelevant'));
+
+          const [value, globalValue] = this.getSetting(
+            'cards-behavior-on-search',
+            local
+          );
+
+          dropdown.setValue(
+            (value as string) || (globalValue as string) || 'highlight'
+          );
+          dropdown.onChange((value) => {
+            this.applySettingsUpdate({
+              'cards-behavior-on-search': {
+                $set: value as 'highlight' | 'hide',
+              },
+            });
+          });
+        });
       });
 
     new Setting(contentEl)

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -297,6 +297,9 @@ export class StateManager {
         this.getSettingRaw('show-board-settings', suppliedSettings) ?? true,
       'show-search':
         this.getSettingRaw('show-search', suppliedSettings) ?? true,
+      'cards-behavior-on-search':
+        this.getSettingRaw('cards-behavior-on-search', suppliedSettings) ??
+        'highlight',
       'tag-colors': this.getSettingRaw('tag-colors', suppliedSettings) ?? [],
       'date-colors': this.getSettingRaw('date-colors', suppliedSettings) ?? [],
     };

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -157,7 +157,7 @@ export const DraggableItem = Preact.memo(function DraggableItem(
   useDragHandle(measureRef, measureRef);
 
   const isMatch = searchQuery
-    ? innerProps.item.data.titleSearch.contains(searchQuery)
+    ? innerProps.item.data.titleSearch.toLowerCase().contains(searchQuery.toLowerCase())
     : false;
 
   const classModifiers: string[] = getItemClassModifiers(innerProps.item);

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -9,7 +9,7 @@ import { Sortable } from 'src/dnd/components/Sortable';
 import { SortPlaceholder } from 'src/dnd/components/SortPlaceholder';
 import { useDragHandle } from 'src/dnd/managers/DragManager';
 
-import { KanbanContext } from '../context';
+import { KanbanContext, SearchContext } from '../context';
 import { c } from '../helpers';
 import { Items } from '../Item/Item';
 import { ItemForm } from '../Item/ItemForm';
@@ -23,7 +23,6 @@ export interface DraggableLaneProps {
   laneIndex: number;
   isStatic?: boolean;
 }
-
 export const DraggableLane = Preact.memo(function DraggableLane({
   isStatic,
   lane,
@@ -31,11 +30,15 @@ export const DraggableLane = Preact.memo(function DraggableLane({
 }: DraggableLaneProps) {
   const { stateManager, boardModifiers, view } =
     Preact.useContext(KanbanContext);
+  const searchQuery = Preact.useContext(SearchContext);
   const [isItemInputVisible, setIsItemInputVisible] = Preact.useState(false);
 
   const path = useNestedEntityPath(laneIndex);
   const laneWidth = stateManager.useSetting('lane-width');
   const insertionMethod = stateManager.useSetting('new-card-insertion-method');
+  const cardsBehaviorOnSearch = stateManager.useSetting(
+    'cards-behavior-on-search'
+  );
   const shouldMarkItemsComplete = !!lane.data.shouldMarkItemsComplete;
 
   const laneStyles = laneWidth ? { width: `${laneWidth}px` } : undefined;
@@ -44,6 +47,14 @@ export const DraggableLane = Preact.memo(function DraggableLane({
   const measureRef = Preact.useRef<HTMLDivElement>(null);
   const dragHandleRef = Preact.useRef<HTMLDivElement>(null);
   const [isSorting, setIsSorting] = Preact.useState(false);
+
+  const childrenAfterFiltering = Preact.useMemo(() => {
+    if (cardsBehaviorOnSearch !== 'hide' || !searchQuery) return lane.children;
+    const searchQueryLowercase = searchQuery.toLowerCase();
+    return lane.children.filter((child) =>
+      child.data.title.toLowerCase().includes(searchQueryLowercase)
+    );
+  }, [cardsBehaviorOnSearch, searchQuery, lane.children]);
 
   const isCompactPrepend = insertionMethod === 'prepend-compact';
   const shouldPrepend = isCompactPrepend || insertionMethod === 'prepend';
@@ -87,7 +98,7 @@ export const DraggableLane = Preact.memo(function DraggableLane({
   const laneContent = (
     <>
       <Items
-        items={lane.children}
+        items={childrenAfterFiltering}
         isStatic={isStatic}
         shouldMarkItemsComplete={shouldMarkItemsComplete}
       />

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -52,7 +52,7 @@ export const DraggableLane = Preact.memo(function DraggableLane({
     if (cardsBehaviorOnSearch !== 'hide' || !searchQuery) return lane.children;
     const searchQueryLowercase = searchQuery.toLowerCase();
     return lane.children.filter((child) =>
-      child.data.titleSearch.toLowerCase().includes(searchQueryLowercase)
+      child.data.titleSearch.toLowerCase().contains(searchQueryLowercase)
     );
   }, [cardsBehaviorOnSearch, searchQuery, lane.children]);
 

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -52,7 +52,7 @@ export const DraggableLane = Preact.memo(function DraggableLane({
     if (cardsBehaviorOnSearch !== 'hide' || !searchQuery) return lane.children;
     const searchQueryLowercase = searchQuery.toLowerCase();
     return lane.children.filter((child) =>
-      child.data.title.toLowerCase().includes(searchQueryLowercase)
+      child.data.titleSearch.toLowerCase().includes(searchQueryLowercase)
     );
   }, [cardsBehaviorOnSearch, searchQuery, lane.children]);
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -154,6 +154,9 @@ export default {
   'Set colors for the date displayed below the card based on the rules below':
     'Set colors for the date displayed below the card based on the rules below',
   'Add date color': 'Add date color',
+  'Cards behavior on search': 'Cards behavior on search',
+  'Highlight relevant': 'Highlight relevant',
+  'Hide irrelevant': 'Hide irrelevant',
 
   // MetadataSettings.tsx
   'Metadata key': 'Metadata key',


### PR DESCRIPTION
### Use case

I'm actively using the `obsidian-kanban` plugin (thank you, guys, for creating such a helpful thing 🤗) for my job search, and it could be tough to find a needed card in the list if you have about 500 items in one lane. Also, it is really handy to have the ability to show just related cards for analytics purposes, duplication finding, and finding missed cards in case you have a lot of lanes.

### Description

This PR adds a new approach for searching and showing relevant cards. The idea is [taken from the Notion template](https://www.notion.so/c074b2c4d8e046c7afd3ee91c9458240?v=f375a8d8887341d0a68f08e442d6a77c).

Besides hiding irrelative cards, it changes the search method to display a broader range of potential matches, avoiding variations in letter casing.
