### PR TITLE
Add helpUrl to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
   "description": "Create markdown-backed Kanban boards in Obsidian.",
   "author": "mgmeyers",
   "authorUrl": "https://github.com/mgmeyers/obsidian-kanban",
+  "helpUrl": "https://publish.obsidian.md/kanban/Obsidian+Kanban+Plugin",
   "isDesktopOnly": false
 }


### PR DESCRIPTION
I am adding helpUrl to the manifest to support the help system integration into Obsidian. Please consider supporting this initiative. Just so you know, this key value in manifest.json must be in the manifest downloaded as part of the plugin in the release.

https://forum.obsidian.md/t/links-to-help-and-manuals-for-plugins-and-themes/70733/8