### PR TITLE
[Feature]: Template for cards

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -110,7 +110,7 @@ export const settingKeyLookup: Record<keyof KanbanSettings, true> = {
   'metadata-keys': true,
   'new-card-insertion-method': true,
   'new-line-trigger': true,
-    'new-card-template': true,
+  'new-card-template': true,
   'new-note-folder': true,
   'new-note-template': true,
   'archive-with-date': true,

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -71,6 +71,7 @@ export interface KanbanSettings {
   'new-card-insertion-method'?: 'prepend' | 'prepend-compact' | 'append';
   'new-line-trigger'?: 'enter' | 'shift-enter';
   'new-note-folder'?: string;
+  'new-card-template'?: string;
   'new-note-template'?: string;
   'archive-with-date'?: boolean;
   'append-archive-date'?: boolean;
@@ -109,6 +110,7 @@ export const settingKeyLookup: Record<keyof KanbanSettings, true> = {
   'metadata-keys': true,
   'new-card-insertion-method': true,
   'new-line-trigger': true,
+    'new-card-template': true,
   'new-note-folder': true,
   'new-note-template': true,
   'archive-with-date': true,
@@ -256,6 +258,24 @@ export class SettingsManager {
           });
         });
       });
+
+  new Setting(contentEl)
+      .setName(t('Card template'))
+      .setDesc(
+          t(
+              'This template will be used when creating new Kanban cards.'
+          )
+      )
+      .then(
+          createSearchSelect({
+              choices: templateFiles,
+              key: 'new-card-template',
+              warningText: templateWarning,
+              local,
+              placeHolderStr: t('No template'),
+              manager: this,
+          })
+      );
 
     new Setting(contentEl)
       .setName(t('Note template'))

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -38,22 +38,28 @@ export function ItemForm({
     }
   );
 
-  const checkTemplate = () => {
+  const readAndSetItemTitleFromTemplate = () => {
     const templateFile = templateCard
         ? stateManager.app.vault.getAbstractFileByPath(templateCard)
         : null;
 
     if (templateFile instanceof TFile) {
-      stateManager.app.vault.read(templateFile).then((data) => {
-        setItemTitle(data)
-      })
+      try {
+        stateManager.app.vault.read(templateFile).then((data) => {
+          setItemTitle(data)
+        })
+      } catch (e) {
+        console.log(e);
+        stateManager.setError(e);
+        setItemTitle("");
+      }
     } else {
       setItemTitle("")
     }
   }
 
   const clear = Preact.useCallback(() => {
-    checkTemplate();
+    readAndSetItemTitleFromTemplate();
     setIsInputVisible(false);
   }, []);
 
@@ -79,7 +85,7 @@ export function ItemForm({
 
       if (title) {
         addItemsFromStrings([title]);
-        checkTemplate();
+        readAndSetItemTitleFromTemplate();
       }
     }
   };
@@ -89,7 +95,7 @@ export function ItemForm({
 
     if (title) {
       addItemsFromStrings([title]);
-      checkTemplate();
+      readAndSetItemTitleFromTemplate();
     }
   };
 
@@ -124,7 +130,7 @@ export function ItemForm({
       <button
         className={c('new-item-button')}
         onClick={() => {
-          checkTemplate();
+          readAndSetItemTitleFromTemplate();
           setIsInputVisible(true);
         }}
         onDragOver={(e) => {

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -8,7 +8,7 @@ import { getDropAction, handlePaste } from '../Editor/helpers';
 import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
 import { c } from '../helpers';
 import { Item } from '../types';
-import { TFile } from "obsidian";
+import { TFile } from 'obsidian';
 
 interface ItemFormProps {
   addItems: (items: Item[]) => void;
@@ -27,7 +27,7 @@ export function ItemForm({
   const { stateManager, view } = Preact.useContext(KanbanContext);
   const inputRef = Preact.useRef<HTMLTextAreaElement>();
 
-  const templateCard = stateManager.useSetting("new-card-template");
+  const templateCard = stateManager.useSetting('new-card-template');
 
   const clickOutsideRef = useOnclickOutside(
     () => {
@@ -40,23 +40,23 @@ export function ItemForm({
 
   const readAndSetItemTitleFromTemplate = () => {
     const templateFile = templateCard
-        ? stateManager.app.vault.getAbstractFileByPath(templateCard)
-        : null;
+      ? stateManager.app.vault.getAbstractFileByPath(templateCard)
+      : null;
 
     if (templateFile instanceof TFile) {
       try {
         stateManager.app.vault.read(templateFile).then((data) => {
-          setItemTitle(data)
-        })
+          setItemTitle(data);
+        });
       } catch (e) {
         console.log(e);
         stateManager.setError(e);
-        setItemTitle("");
+        setItemTitle('');
       }
     } else {
-      setItemTitle("")
+      setItemTitle('');
     }
-  }
+  };
 
   const clear = Preact.useCallback(() => {
     readAndSetItemTitleFromTemplate();

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -8,6 +8,7 @@ import { getDropAction, handlePaste } from '../Editor/helpers';
 import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
 import { c } from '../helpers';
 import { Item } from '../types';
+import { TFile } from "obsidian";
 
 interface ItemFormProps {
   addItems: (items: Item[]) => void;
@@ -26,6 +27,8 @@ export function ItemForm({
   const { stateManager, view } = Preact.useContext(KanbanContext);
   const inputRef = Preact.useRef<HTMLTextAreaElement>();
 
+  const templateCard = stateManager.useSetting("new-card-template");
+
   const clickOutsideRef = useOnclickOutside(
     () => {
       setIsInputVisible(false);
@@ -35,8 +38,22 @@ export function ItemForm({
     }
   );
 
+  const checkTemplate = () => {
+    const templateFile = templateCard
+        ? stateManager.app.vault.getAbstractFileByPath(templateCard)
+        : null;
+
+    if (templateFile instanceof TFile) {
+      stateManager.app.vault.read(templateFile).then((data) => {
+        setItemTitle(data)
+      })
+    } else {
+      setItemTitle("")
+    }
+  }
+
   const clear = Preact.useCallback(() => {
-    setItemTitle('');
+    checkTemplate();
     setIsInputVisible(false);
   }, []);
 
@@ -62,7 +79,7 @@ export function ItemForm({
 
       if (title) {
         addItemsFromStrings([title]);
-        setItemTitle('');
+        checkTemplate();
       }
     }
   };
@@ -72,7 +89,7 @@ export function ItemForm({
 
     if (title) {
       addItemsFromStrings([title]);
-      setItemTitle('');
+      checkTemplate();
     }
   };
 
@@ -106,7 +123,10 @@ export function ItemForm({
     <div className={c('item-button-wrapper')}>
       <button
         className={c('new-item-button')}
-        onClick={() => setIsInputVisible(true)}
+        onClick={() => {
+          checkTemplate();
+          setIsInputVisible(true);
+        }}
         onDragOver={(e) => {
           if (getDropAction(stateManager, e.dataTransfer)) {
             setIsInputVisible(true);

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -57,6 +57,8 @@ export default {
     'These settings will take precedence over the default Kanban board settings.',
   'Set the default Kanban board settings. Settings can be overridden on a board-by-board basis.':
     'Set the default Kanban board settings. Settings can be overridden on a board-by-board basis.',
+  'Card template': 'Card template',
+  'This template will be used when creating new Kanban cards.' : 'This template will be used when creating new Kanban cards.',
   'Note template': 'Note template',
   'This template will be used when creating new notes from Kanban cards.':
     'This template will be used when creating new notes from Kanban cards.',


### PR DESCRIPTION
As first mentioned by: https://github.com/mgmeyers/obsidian-kanban/issues/837 

## Use Case

This code creates a new setting option to allow users to set and use a template for creating cards. 

## Evidence and Test Cases

**GIVEN  I have a template set WHEN I create a card, THEN create a new card with that template** 

<img width="620" alt="Screenshot 2023-12-20 at 17 13 57" src="https://github.com/mgmeyers/obsidian-kanban/assets/24465934/f02838b9-8882-4a0a-9256-9482ba2b955f">
<img width="650" alt="image" src="https://github.com/mgmeyers/obsidian-kanban/assets/24465934/56494658-e77b-47e9-9bb1-dcc293469659">
<img width="1017" alt="Screenshot 2023-12-20 at 17 14 11" src="https://github.com/mgmeyers/obsidian-kanban/assets/24465934/d0e2eeeb-b442-4876-be38-6b81e3e33913">


**GIVEN I don't  have a template set WHEN I create a card, THEN create a new card without any template**  

<img width="652" alt="Screenshot 2023-12-20 at 17 14 45" src="https://github.com/mgmeyers/obsidian-kanban/assets/24465934/bafc7f84-539e-4bb8-ab44-2a3e889371b3">
<img width="955" alt="Screenshot 2023-12-20 at 17 14 54" src="https://github.com/mgmeyers/obsidian-kanban/assets/24465934/e7b0a9d0-30da-4643-8497-0fc6367bf8bb">

**GIVEN I have a template set WHEN I create a card AND change the template, THEN create a new card with the new template**
![image](https://github.com/mgmeyers/obsidian-kanban/assets/24465934/90e7fa63-b034-495c-9dac-5190e07aafdd)
![image](https://github.com/mgmeyers/obsidian-kanban/assets/24465934/3a7ee6f5-871a-4dd7-8875-d3811cbede36)

