### PR TITLE
[Feature] add setting to search kanban board by clicking tags

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -54,6 +54,7 @@ export interface KanbanSettings {
   'hide-date-in-title'?: boolean;
   'hide-tags-display'?: boolean;
   'hide-tags-in-title'?: boolean;
+  'tag-action'?: 'kanban' | 'obsidian';
   'lane-width'?: number;
   'full-list-lane-width'?: boolean;
   'link-date-to-daily-note'?: boolean;
@@ -96,6 +97,7 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'hide-date-in-title',
   'hide-tags-display',
   'hide-tags-in-title',
+  'tag-action',
   'lane-width',
   'link-date-to-daily-note',
   'list-collapse',
@@ -531,6 +533,27 @@ export class SettingsManager {
                 });
               });
           });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Tag action'))
+      .setDesc(
+        t('This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.')
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption('kanban', t('Search Kanban Board'));
+        dropdown.addOption('obsidian', t('Search Obsidian Vault'));
+
+        const [value, globalValue] = this.getSetting('tag-action', local);
+
+        dropdown.setValue((value as string) || (globalValue as string) || 'obsidian');
+        dropdown.onChange((value) => {
+          this.applySettingsUpdate({
+            'tag-action': {
+              $set: value as 'kanban' | 'obsidian',
+            },
+          });
+        });
       });
 
     new Setting(contentEl)

--- a/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -152,9 +152,20 @@ export const StaticMarkdownRenderer = memo(function StaticMarkdownRenderer({
       // Open a tag search
       if (closestAnchor.hasClass('tag')) {
         e.preventDefault();
+        const tag = closestAnchor.getAttr('href');
+        const tagAction = stateManager.getSetting('tag-action');
+
+        if (tagAction === 'kanban') {
+          setSearchQuery(tag);
+          setDebouncedSearchQuery(tag);
+          setIsSearching(true);
+
+          return;
+        }
+
         (stateManager.app as any).internalPlugins
           .getPluginById('global-search')
-          .instance.openGlobalSearch(`tag:${closestAnchor.getAttr('href')}`);
+          .instance.openGlobalSearch(`tag:${tag}`);
         return;
       }
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -126,6 +126,11 @@ export default {
   'Hide card display tags': 'Hide card display tags',
   'When toggled, tags will not be displayed below the card title.':
     'When toggled, tags will not be displayed below the card title.',
+  'Tag action': 'Tag action',
+  'Search Kanban Board': 'Search Kanban Board',
+  'Search Obsidian Vault': 'Search Obsidian Vault',
+  'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.':
+    'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.',
   'Display tag colors': 'Display tag colors',
   'Set colors for the tags displayed below the card title.':
     'Set colors for the tags displayed below the card title.',


### PR DESCRIPTION
This video demonstrates the existing "click tag" functionality, and the new "Tag Action" setting which changes the "click tag" functionality:

https://github.com/mgmeyers/obsidian-kanban/assets/134939/3e3d0edc-8750-49e5-a29a-f2a9a0c54217



