### PR TITLE
Hide a scroll bar appearing on the right of some Kanban items

### DIFF
--- a/src/main.less
+++ b/src/main.less
@@ -459,6 +459,7 @@ button.kanban-plugin__new-item-button {
 .kanban-plugin__markdown-preview-view > div > * {
   overflow-x: auto;
   overflow-wrap: break-word;
+  overflow-y: hidden;
 }
 
 .kanban-plugin__markdown-preview-view > div > *:first-child,


### PR DESCRIPTION
Short CSS fix.

Resolves #677