### PR TITLE
Fix inline metadata class names

### DIFF
--- a/src/components/Item/InlineMetadata.tsx
+++ b/src/components/Item/InlineMetadata.tsx
@@ -39,6 +39,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
         const isEmojiPriority = isEmoji && m.key === 'priority';
         const isDate = !!val?.ts;
         let label = isEmoji ? lableToIcon(m.key, m.value) : lableToName(m.key);
+        const slug = m.key.replace(/[^a-zA-Z0-9_]/g, '-');
 
         if (!isEmoji) label += ': ';
 
@@ -46,7 +47,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
           <span
             className={classcat([
               c('item-task-inline-metadata-item'),
-              m.key.toLowerCase().replace(/[^a-z0-9]/g, '-'),
+              c(`inline-metadata__${slug}`),
               {
                 'is-task-metadata': isTaskMetadata,
                 'is-emoji': isEmoji,

--- a/src/components/Item/InlineMetadata.tsx
+++ b/src/components/Item/InlineMetadata.tsx
@@ -46,7 +46,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
           <span
             className={classcat([
               c('item-task-inline-metadata-item'),
-              m.key.replace(/[^a-z0-9]/g, '-'),
+              m.key.toLowerCase().replace(/[^a-z0-9]/g, '-'),
               {
                 'is-task-metadata': isTaskMetadata,
                 'is-emoji': isEmoji,


### PR DESCRIPTION
The previous logic would replace uppercase letters with hyphens, e.g.:

1. `Story Points` would become `-tory--oints`.
2. `storyPoints` would become `story-oints`.

This small PR fixes that, making sure to abide to the spirit of the code, which was to keep keys lowercase.

### Follow up questions that I didn't address in this PR but I'm willing to contribute:

1. Would we really want to enforce only lowercase letters? The CSS specs allows underscores and uppercase class names.
2. I think the classname for the key should also be prefixed and namespaced, as in the current status it will result in potentially dangerous/non-specific class names. I propose adding the base namespace and then perhaps an extra identifier, something like: `kanban-plugin__item-task-inline-metadata-item__key-${myKey}`.