### PR TITLE
Fix inline metadata not recognized if not in first line

### DIFF
--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -49,7 +49,6 @@ export function hydrateItem(stateManager: StateManager, item: Item) {
   const firstLineEnd = item.data.title.indexOf('\n');
   const inlineFields = extractInlineFields(item.data.title, true);
 
-  inlineFields?.length && console.log({ inlineFields });
 
   if (inlineFields?.length) {
     const inlineMetadata = (item.data.metadata.inlineMetadata = inlineFields.reduce((acc, curr) => {

--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -49,11 +49,15 @@ export function hydrateItem(stateManager: StateManager, item: Item) {
   const firstLineEnd = item.data.title.indexOf('\n');
   const inlineFields = extractInlineFields(item.data.title, true);
 
+  inlineFields?.length && console.log({ inlineFields });
+
   if (inlineFields?.length) {
-    const inlineMetadata = (item.data.metadata.inlineMetadata =
-      firstLineEnd > 0
-        ? inlineFields.filter((f) => taskFields.has(f.key) && f.end < firstLineEnd)
-        : inlineFields);
+    const inlineMetadata = (item.data.metadata.inlineMetadata = inlineFields.reduce((acc, curr) => {
+      if (!taskFields.has(curr.key)) acc.push(curr);
+      else if (firstLineEnd <= 0 || curr.end < firstLineEnd) acc.push(curr);
+
+      return acc;
+    }, []));
 
     const moveTaskData = stateManager.getSetting('move-task-metadata');
     const moveMetadata = stateManager.getSetting('move-inline-metadata');

--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -64,8 +64,7 @@ export function hydrateItem(stateManager: StateManager, item: Item) {
 
     if (moveTaskData || moveMetadata) {
       let title = item.data.title;
-      for (let i = inlineMetadata.length - 1; i >= 0; i--) {
-        const item = inlineMetadata[i];
+      for (const item of [...inlineMetadata].reverse()) {
         const isTask = taskFields.has(item.key);
 
         if (isTask && !moveTaskData) continue;


### PR DESCRIPTION
I was a bit baffled why the inline metadata was not correctly moved to the footer, even when the options was on, if the metadata was somewhere else in the body of the card. I used to separate some of the inline metadata for clarity and readability, and that surprised me.

I realized the code in `hydrateBoard.ts` was excluding anything outside the first line. I dug a bit in the repo to understand why, and I think—also considering the code—that the spirit of the code was for that to be applied only to `Tasks` metadata, which, being emojis and very peculiar, makes sense as we don't want anything in the body to be captured.

However, I think Dataview metadata was probably intended to be captured, so I fixed that. The new code does:

1. Includes all inline Dataview metadata, regardless of its position in the card.
2. Include all inline Tasks metadata, only if they are within the first line.

---

Note that I also changed the `for loop`, just for readability. This is probably subjective and I so I made this change in a different commit. I can revert that commit if you disagree to that change: I find it easier to read this way, personally.