### PR TITLE
Add support for merging metadata in metadata table

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -8,7 +8,7 @@ import { getDefaultDateFormat, getDefaultTimeFormat } from './components/helpers
 import { Board, BoardTemplate, Item } from './components/types';
 import { ListFormat } from './parsers/List';
 import { BaseFormat, frontmatterKey, shouldRefreshBoard } from './parsers/common';
-import { defaultDateTrigger, defaultTimeTrigger } from './settingHelpers';
+import { defaultDateTrigger, defaultMetadataPosition, defaultTimeTrigger } from './settingHelpers';
 
 export class StateManager {
   onEmpty: () => void;
@@ -228,12 +228,13 @@ export class StateManager {
       'date-display-format': dateDisplayFormat,
       'date-time-display-format': dateDisplayFormat + ' ' + timeFormat,
       'date-trigger': this.getSettingRaw('date-trigger', suppliedSettings) || defaultDateTrigger,
+      'inline-metadata-position':
+        this.getSettingRaw('inline-metadata-position', suppliedSettings) || defaultMetadataPosition,
       'time-format': timeFormat,
       'time-trigger': this.getSettingRaw('time-trigger', suppliedSettings) || defaultTimeTrigger,
       'link-date-to-daily-note': this.getSettingRaw('link-date-to-daily-note', suppliedSettings),
       'move-dates': this.getSettingRaw('move-dates', suppliedSettings),
       'move-tags': this.getSettingRaw('move-tags', suppliedSettings),
-      'move-inline-metadata': this.getSettingRaw('move-inline-metadata', suppliedSettings),
       'move-task-metadata': this.getSettingRaw('move-task-metadata', suppliedSettings),
       'metadata-keys': [...globalKeys, ...localKeys],
       'archive-date-separator': this.getSettingRaw('archive-date-separator') || '',

--- a/src/components/Item/InlineMetadata.tsx
+++ b/src/components/Item/InlineMetadata.tsx
@@ -2,7 +2,6 @@ import classcat from 'classcat';
 import { useContext } from 'preact/compat';
 import { StateManager } from 'src/StateManager';
 import {
-  InlineField,
   getDataviewPlugin,
   lableToIcon,
   lableToName,
@@ -11,7 +10,7 @@ import {
 
 import { SearchContext } from '../context';
 import { c, parseMetadataWithOptions } from '../helpers';
-import { DataKey, Item, PageData } from '../types';
+import { Item } from '../types';
 import { MetadataValue } from './MetadataTable';
 
 interface InlineMetadataProps {
@@ -26,7 +25,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
   const moveTaskMetadata = stateManager.useSetting('move-task-metadata');
   const { inlineMetadata } = item.data.metadata;
 
-  if (!inlineMetadata || (!displayMetadataInFooter && !moveTaskMetadata)) return null;
+  if (!inlineMetadata || (displayMetadataInFooter && !moveTaskMetadata)) return null;
 
   const dataview = getDataviewPlugin();
 
@@ -34,7 +33,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
     <span className={c('item-task-metadata')}>
       {inlineMetadata.map((m, i) => {
         const data = parseMetadataWithOptions(m, metaKeys);
-        const { metadataKey: key, label: metaLabel, value } = data;
+        const { metadataKey: key, value } = data;
         const isTaskMetadata = taskFields.has(key);
         if (!moveTaskMetadata && isTaskMetadata) return null;
         if (!displayMetadataInFooter && !isTaskMetadata) return null;
@@ -44,8 +43,8 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
         const isEmojiPriority = isEmoji && key === 'priority';
         const isDate = !!val?.ts;
 
-        let label = isEmoji ? lableToIcon(m.key, m.value) : lableToName(m.key);
-        const slug = m.key.replace(/[^a-zA-Z0-9_]/g, '-');
+        let label = isEmoji ? lableToIcon(key, value) : lableToName(key);
+        const slug = key.replace(/[^a-zA-Z0-9_]/g, '-');
 
         if (!isEmoji) label += ': ';
 

--- a/src/components/Item/InlineMetadata.tsx
+++ b/src/components/Item/InlineMetadata.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/parsers/helpers/inlineMetadata';
 
 import { SearchContext } from '../context';
-import { c } from '../helpers';
+import { c, parseMetadataWithOptions } from '../helpers';
 import { DataKey, Item, PageData } from '../types';
 import { MetadataValue } from './MetadataTable';
 
@@ -19,31 +19,15 @@ interface InlineMetadataProps {
   stateManager: StateManager;
 }
 
-function parseMetadataWithOptions(data: InlineField, metadataKeys: DataKey[]): PageData {
-  const options = metadataKeys.find((opts) => opts.metadataKey === data.key);
-
-  return options
-    ? {
-        ...options,
-        value: data.value,
-      }
-    : {
-        containsMarkdown: false,
-        label: data.key,
-        metadataKey: data.key,
-        shouldHideLabel: false,
-        value: data.value,
-      };
-}
-
 export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
   const search = useContext(SearchContext);
-  const metaKeys = stateManager.useSetting('metadata-keys');
-  const moveMetadata = stateManager.useSetting('move-inline-metadata');
+  const metaKeys = stateManager.getSetting('metadata-keys');
+  const displayMetadataInFooter = stateManager.useSetting('inline-metadata-position') === 'footer';
   const moveTaskMetadata = stateManager.useSetting('move-task-metadata');
   const { inlineMetadata } = item.data.metadata;
 
-  if (!inlineMetadata || (!moveMetadata && !moveTaskMetadata)) return null;
+  if (!inlineMetadata || (!displayMetadataInFooter && !moveTaskMetadata)) return null;
+
   const dataview = getDataviewPlugin();
 
   return (
@@ -53,7 +37,7 @@ export function InlineMetadata({ item, stateManager }: InlineMetadataProps) {
         const { metadataKey: key, label: metaLabel, value } = data;
         const isTaskMetadata = taskFields.has(key);
         if (!moveTaskMetadata && isTaskMetadata) return null;
-        if (!moveMetadata && !isTaskMetadata) return null;
+        if (!displayMetadataInFooter && !isTaskMetadata) return null;
 
         const isEmoji = m.wrapping === 'emoji-shorthand';
         const val = dataview?.api?.parse(value) ?? value;

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -107,6 +107,9 @@ const ItemInner = memo(function ItemInner({
     return {};
   }, [editState]);
 
+  const inlineMetadataPosition = stateManager.getSetting('inline-metadata-position');
+  const metadataKeys = stateManager.getSetting('metadata-keys');
+
   return (
     <div
       // eslint-disable-next-line react/no-unknown-property
@@ -132,7 +135,12 @@ const ItemInner = memo(function ItemInner({
         />
         <ItemMenuButton editState={editState} setEditState={setEditState} showMenu={showItemMenu} />
       </div>
-      <ItemMetadata searchQuery={isMatch ? searchQuery : undefined} item={item} />
+      <ItemMetadata
+        searchQuery={isMatch ? searchQuery : undefined}
+        item={item}
+        mergeInlineMetadata={inlineMetadataPosition === 'metadata-table'}
+        metadataKeys={metadataKeys}
+      />
     </div>
   );
 });

--- a/src/components/Item/MetadataTable.tsx
+++ b/src/components/Item/MetadataTable.tsx
@@ -4,7 +4,7 @@ import { ComponentChild } from 'preact';
 import { memo, useContext } from 'preact/compat';
 import { KanbanView } from 'src/KanbanView';
 import { StateManager } from 'src/StateManager';
-import { InlineField } from 'src/parsers/helpers/inlineMetadata';
+import { InlineField, taskFields } from 'src/parsers/helpers/inlineMetadata';
 
 import { StaticMarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
 import { KanbanContext } from '../context';
@@ -25,6 +25,7 @@ function mergeMetadata(
   metadataKeys: DataKey[]
 ) {
   return inlineMetadata.reduce((acc, curr) => {
+    if (taskFields.has(curr.key)) return acc;
     const data = parseMetadataWithOptions(curr, metadataKeys);
 
     acc[curr.key] = data;

--- a/src/components/Table/helpers.tsx
+++ b/src/components/Table/helpers.tsx
@@ -144,7 +144,7 @@ export function useTableColumns(boardData: Board, stateManager: StateManager) {
   const shouldShowRelativeDate = stateManager.useSetting('show-relative-date');
   const moveDates = stateManager.useSetting('move-dates');
   const moveTags = stateManager.useSetting('move-tags');
-  const moveMetadata = stateManager.useSetting('move-inline-metadata');
+  const displayMetadataInBody = stateManager.useSetting('inline-metadata-position') === 'body';
   const moveTaskMetadata = stateManager.useSetting('move-task-metadata');
   const tableSizing = stateManager.useSetting('table-sizing') || {};
 
@@ -277,7 +277,7 @@ export function useTableColumns(boardData: Board, stateManager: StateManager) {
 
               const isTaskMetadata = taskFields.has(m.key);
               if (!moveTaskMetadata && isTaskMetadata) return null;
-              if (!moveMetadata && !isTaskMetadata) return null;
+              if (displayMetadataInBody && !isTaskMetadata) return null;
 
               const isEmoji = m.wrapping === 'emoji-shorthand';
               const val = getDataviewPlugin()?.api?.parse(m.value) ?? m.value;

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -5,9 +5,10 @@ import { StateUpdater, useMemo } from 'preact/hooks';
 import { StateManager } from 'src/StateManager';
 import { Path } from 'src/dnd/types';
 import { getEntityFromPath } from 'src/dnd/util/data';
+import { InlineField } from 'src/parsers/helpers/inlineMetadata';
 
 import { SearchContextProps } from './context';
-import { Board, DateColor, Item, Lane, TagColor } from './types';
+import { Board, DataKey, DateColor, Item, Lane, PageData, TagColor } from './types';
 
 export const baseClassName = 'kanban-plugin';
 
@@ -275,6 +276,23 @@ export function getDateColorFn(
 
     return null;
   };
+}
+
+export function parseMetadataWithOptions(data: InlineField, metadataKeys: DataKey[]): PageData {
+  const options = metadataKeys.find((opts) => opts.metadataKey === data.key);
+
+  return options
+    ? {
+        ...options,
+        value: data.value,
+      }
+    : {
+        containsMarkdown: false,
+        label: data.key,
+        metadataKey: data.key,
+        shouldHideLabel: false,
+        value: data.value,
+      };
 }
 
 export function useOnMount(refs: RefObject<HTMLElement>[], cb: () => void, onUnmount?: () => void) {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -107,9 +107,12 @@ const en = {
   'Move task data to card footer': 'Move task data to card footer',
   "When toggled, task data (from the Tasks plugin) will be displayed in the card's footer instead of the card's body.":
     "When toggled, task data (from the Tasks plugin) will be displayed in the card's footer instead of the card's body.",
-  'Move inline metadata to card footer': 'Move inline metadata to card footer',
-  "When toggled, inline metadata (from the Dataview plugin) will be displayed in the card's footer instead of the card's body.":
-    "When toggled, inline metadata (from the Dataview plugin) will be displayed in the card's footer instead of the card's body.",
+  'Inline metadata position': 'Inline metadata position',
+  'Controls where the inline metadata (from the Dataview plugin) will be displayed.':
+    'Controls where the inline metadata (from the Dataview plugin) will be displayed.',
+  'Card body': 'Card body',
+  'Card footer': 'Card footer',
+  'Merge with linked page metadata': 'Merge with linked page metadata',
 
   'Hide card counts in list titles': 'Hide card counts in list titles',
   'When toggled, card counts are hidden from the list title':

--- a/src/parsers/common.ts
+++ b/src/parsers/common.ts
@@ -250,7 +250,7 @@ export function shouldRefreshBoard(oldSettings: KanbanSettings, newSettings: Kan
     'time-format',
     'move-dates',
     'move-tags',
-    'move-inline-metadata',
+    'inline-metadata-position',
     'move-task-metadata',
     'hide-card-count',
     'tag-colors',

--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -58,15 +58,15 @@ export function hydrateItem(stateManager: StateManager, item: Item) {
     }, []));
 
     const moveTaskData = stateManager.getSetting('move-task-metadata');
-    const moveMetadata = stateManager.getSetting('move-inline-metadata');
+    const displayMetadataInBody = stateManager.getSetting('inline-metadata-position') === 'body';
 
-    if (moveTaskData || moveMetadata) {
+    if (moveTaskData || !displayMetadataInBody) {
       let title = item.data.title;
       for (const item of [...inlineMetadata].reverse()) {
         const isTask = taskFields.has(item.key);
 
         if (isTask && !moveTaskData) continue;
-        if (!isTask && !moveMetadata) continue;
+        if (!isTask && displayMetadataInBody) continue;
 
         title = title.slice(0, item.start) + title.slice(item.end);
       }

--- a/src/settingHelpers.ts
+++ b/src/settingHelpers.ts
@@ -8,6 +8,7 @@ import { t } from './lang/helpers';
 
 export const defaultDateTrigger = '@';
 export const defaultTimeTrigger = '@@';
+export const defaultMetadataPosition = 'body';
 
 export function getFolderChoices(app: App) {
   const folderList: IChoices.Choice[] = [];


### PR DESCRIPTION
> My last PR for today, I swear! 😅 
> This PR adds a feature I'd love to have, hence it's a bit larger.

## What does this PR do?

This PR introduces a new setting option in the “Move inline metadata to card footer” that allows inline metadata to be displayed (and merged) within the Metadata table at the bottom of the card. This makes it easier to achieve a consistent look between cards whose metadata comes from linked pages and those which have it inline (in my case, I sometimes want to create a card without an attached note, but have the same metadata I'd use within my note YAML).

Because of this change, I renamed the setting to “Inline metadata position” and changed the help text. Also changed the toggle to a dropdown with three options:

1. “Card body” – same as previous setting when it was off.
2. “Card footer” – same as previous setting when it was on.
3. “Merge with linked page metadata” – the new setting, achieving this behavior.

> [!WARNING]  
> I also renamed the setting id to match its new function and I did not include any backwards compatibility. This may be fine since this setting was introduced in beta and is not currently published. If required, I can include some backwards compatibility by either: (a) changing the id back to what it was (b) checking both settings every time.
> I believe this is cumbersome and probably unnecessary.

### More notes on the behavior

1. Task metadata are excluded as the setting is only aimed at Dataview inline data. As such, Task metadata behavior has not been changed.
2. If multiple metadata with the same key are found, only one is displayed in the table.
3. If an inline metadata conflicts with a linked page metadata, the inline data takes priority (same philosophy as `local` settings override `global` settings).