### PR TITLE
Fix bug in date display color overriding 'before' ranges

### DIFF
--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -280,6 +280,10 @@ export function getDateColorFn(dateColors: DateColor[]) {
     if (b[0] === 'after') return -1;
     if (b[0] === 'before') return -1;
 
+    if (a[1].direction === 'before' && b[1].direction === 'before') {
+      return a[0].isBefore(b[0]) ? 1 : -1;
+    }
+
     return a[0].isBefore(b[0]) ? -1 : 1;
   });
 


### PR DESCRIPTION
Closes #831 

Reverses the sorting order for date colors with 'before' directions, which prioritizes closer date ranges.

## Settings

<img width="1030" alt="Screenshot 2024-06-27 at 4 50 26 PM" src="https://github.com/mgmeyers/obsidian-kanban/assets/24641573/51d651fb-7731-44cc-ab21-7cb4fb82bdd9">

## Before The Change

<img width="865" alt="Screenshot 2024-06-27 at 4 50 16 PM" src="https://github.com/mgmeyers/obsidian-kanban/assets/24641573/54555e76-d8b8-42bb-843a-a4d86440ecff">

* The issue here is the 30 day 'before' card is ALSO dark red instead of light red. The 60 day 'before' date range is overriding the 30 day range.

## After The Change

<img width="865" alt="Screenshot 2024-06-27 at 4 51 02 PM" src="https://github.com/mgmeyers/obsidian-kanban/assets/24641573/bbc346c5-f47b-4f87-b763-718384274550">

