### PR TITLE
Use standard icon size variables

### DIFF
--- a/src/styles.less
+++ b/src/styles.less
@@ -260,7 +260,8 @@ button.kanban-plugin__search-cancel-button .kanban-plugin__icon {
 .kanban-plugin__icon {
   display: inline-block;
   line-height: 1;
-  --icon-size: 1em;
+  --icon-size: var(--icon-m);
+  --icon-stroke: var(--icon-m-stroke-width);
 }
 
 .kanban-plugin__board {


### PR DESCRIPTION
Use the default `--icon-` variables for icon sizes, to avoid interfering with themes and font size changes