### PR TITLE
Fixed behaviour for tags in titles and file properties

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -86,6 +86,8 @@ export interface KanbanSettings {
   'show-view-as-markdown'?: boolean;
   'table-sizing'?: Record<string, number>;
   'tag-action'?: 'kanban' | 'obsidian';
+  'tag-in-title'?: boolean;
+  'tag-in-properties'?: boolean;
   'tag-colors'?: TagColor[];
   'tag-sort'?: TagSort[];
   'time-format'?: string;
@@ -134,6 +136,8 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'show-view-as-markdown',
   'table-sizing',
   'tag-action',
+  'tag-in-title',
+  'tag-in-properties',
   'tag-colors',
   'tag-sort',
   'time-format',
@@ -535,6 +539,92 @@ export class SettingsManager {
             },
           });
         });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Add tags to note title'))
+      .setDesc(
+        t(
+          'When toggled, the tags used in the card title will also be added to the note title without the "#" before them'
+        )
+      )
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('tag-in-title', local);
+
+            if (value !== undefined) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined) {
+              toggle.setValue(globalValue as boolean);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'tag-in-title': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('tag-in-title', local);
+                toggleComponent.setValue(!!globalValue);
+
+                this.applySettingsUpdate({
+                  $unset: ['tag-in-title'],
+                });
+              });
+          });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Add tags to note properties'))
+      .setDesc(
+        t('When toggled, the tags used in the card title will also be added to the note properties')
+      )
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('tag-in-properties', local);
+
+            if (value !== undefined) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined) {
+              toggle.setValue(globalValue as boolean);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'tag-in-properties': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('tag-in-properties', local);
+                toggleComponent.setValue(!!globalValue);
+
+                this.applySettingsUpdate({
+                  $unset: ['tag-in-properties'],
+                });
+              });
+          });
       });
 
     new Setting(contentEl).then((setting) => {

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -258,6 +258,8 @@ export class StateManager {
       'tag-sort': this.getSettingRaw('tag-sort', suppliedSettings) ?? [],
       'date-colors': this.getSettingRaw('date-colors', suppliedSettings) ?? [],
       'tag-action': this.getSettingRaw('tag-action', suppliedSettings) ?? 'obsidian',
+      'tag-in-title': this.getSettingRaw('tag-in-title', suppliedSettings) ?? false,
+      'tag-in-properties': this.getSettingRaw('tag-in-properties', suppliedSettings) ?? false,
     };
   }
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -132,10 +132,16 @@ const en = {
   'Archive date/time format': 'Archive date/time format',
   'Kanban Plugin': 'Kanban Plugin',
   'Tag click action': 'Tag click action',
+  'Add tags to note title': 'Add tags to note title',
+  'Add tags to note properties': 'Add tags to note properties',
   'Search Kanban Board': 'Search Kanban Board',
   'Search Obsidian Vault': 'Search Obsidian Vault',
   'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.':
     'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.',
+  'When toggled, the tags used in the card title will also be added to the note title without the "#" before them':
+    'When toggled, the tags used in the card title will also be added to the note title without the "#" before them',
+  'When toggled, the tags used in the card title will also be added to the note properties':
+    'When toggled, the tags used in the card title will also be added to the note properties',
   'Tag colors': 'Tag colors',
   'Set colors for tags displayed in cards.': 'Set colors for tags displayed in cards.',
   'Linked Page Metadata': 'Linked Page Metadata',


### PR DESCRIPTION
- Added settings for adding the tags in title and/or porperties.
- Modified `New note from card` function to not remove the tags from card title
- Modified `New note from card` to use the settings to either leave the tags in the note title or not
- Modified `New note from card` to use the settings to either add the tags to note properties or not.