### PR TITLE
Open Search with Find & Replace hotkey

### DIFF
--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -97,7 +97,10 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
 
   useEffect(() => {
     const onSearchHotkey = (data: { commandId: string; data: string }) => {
-      if (data.commandId === 'editor:open-search') {
+      if (
+        data.commandId === 'editor:open-search' ||
+        data.commandId === 'editor:open-search-replace'
+      ) {
         if (typeof data.data === 'string') {
           setIsSearching(true);
           setSearchQuery(data.data);


### PR DESCRIPTION
Hi Matthew - thanks for creating this plugin! I've found it very useful.


This is a pretty small change suggestion that I've found very helpful, so perhaps others will too.
This PR allows the use of the Find and Replace hotkey to open the Search function, in addition to the Find hotkey.

This will be useful for users who have rebound Ctrl + F from "Find" to "Find and Replace", allowing them to open the search function with their preferred hotkey.

The Find & Replace hotkey is not currently used in the Kanboard view, so this should have no impact on existing functionality.