### PR TITLE
Current board's folder as default new note folder and customizable new note folder for a single board  

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -65,12 +65,12 @@ export function useItemMenu({
                 .trim()
                 .replace(condenceWhiteSpaceRE, ' ');
 
-              const newNoteFolder = stateManager.getSetting('new-note-folder');
+              const newNoteFolder = stateManager.state.data.frontmatter['new-note-folder'] ?? stateManager.getSetting('new-note-folder');
               const newNoteTemplatePath = stateManager.getSetting('new-note-template');
 
               const targetFolder = newNoteFolder
                 ? (stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string) as TFolder)
-                : stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
+                : stateManager.app.vault.getAbstractFileByPath(stateManager.file.path).parent;
 
               const newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
                 targetFolder,


### PR DESCRIPTION
## Previous behavior
1. When `Note folder` setting is left as `Default folder` and a new note is created from a card, the note gets created in the root dir of the vault, I don't think this is the appropriate default behavior as most users would expect it to get created in the same folder as the kanban board.
2. There is no way to set a default folder for a single kanban board, the only existing option is to set a global folder for notes, which doesn't look great in case of having multiple boards in different folder.  

## New Behavior
1. When `Note folder` setting is left as `Default folder` and a new note is created from a card, the default behavior is to create it in the same folder as the board.
2. You can set the new note folder for a single kanban board by:
        - Openning the board as markdown
        - Creating a new property with name `new-note-folder`. The values should be the path to the folder starting from your vault as root. For example if you have inside your vault a folder called `projects` with a nested folder named `project-x` the value should be just `project/project-x`
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6e996123-592e-41f7-8007-d71412ab196f">

3. The local property `new-note-folder` has higher priority than the value in the `Note folder` setting.