### PR TITLE
Feat: add toggle setting to place 'Move to List' card menu item at top

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -69,6 +69,7 @@ export interface KanbanSettings {
   'list-collapse'?: boolean[];
   'max-archive-size'?: number;
   'metadata-keys'?: DataKey[];
+  'menu-move-to-list-first'?: boolean;
   'move-dates'?: boolean;
   'move-tags'?: boolean;
   'move-task-metadata'?: boolean;
@@ -327,6 +328,46 @@ export class SettingsManager {
 
                 this.applySettingsUpdate({
                   $unset: ['hide-card-count'],
+                });
+              });
+          });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Make "Move to List" the first option on the menu'))
+      .setDesc(t('When toggled, "Move to List" will be the first option in the card menu.'))
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('menu-move-to-list-first', local);
+
+            if (value !== undefined) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined) {
+              toggle.setValue(globalValue as boolean);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'menu-move-to-list-first': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('menu-move-to-list-first', local);
+                toggleComponent.setValue(!!globalValue);
+
+                this.applySettingsUpdate({
+                  $unset: ['menu-move-to-list-first'],
                 });
               });
           });

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -117,6 +117,10 @@ const en = {
   'Hide card counts in list titles': 'Hide card counts in list titles',
   'When toggled, card counts are hidden from the list title':
     'When toggled, card counts are hidden from the list title',
+  'Make "Move to List" the first option on the menu':
+    'Make "Move to List" the first option on the menu',
+  'When toggled, "Move to List" will be the first option in the card menu.':
+    'When toggled, "Move to List" will be the first option in the card menu.',
   'Link dates to daily notes': 'Link dates to daily notes',
   'When toggled, dates will link to daily notes. Eg. [[2021-04-26]]':
     'When toggled, dates will link to daily notes. Eg. [[2021-04-26]]',


### PR DESCRIPTION
Hello, thanks for your work this great plug-in! I would like to propose a small improvement.

This patch introduces a new toggle Setting which allows placing 'Move to List' item on top of the card menu. It is the most used menu item from my personal experience so I decided to introduce an option to improve its ergonomics by moving it closer to the initial click.