### PR TITLE
Add support for placing all Kanban data under specific level-1 header

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -32,7 +32,7 @@ import {
 import { getParentWindow } from './dnd/util/getWindow';
 import { t } from './lang/helpers';
 import KanbanPlugin from './main';
-import { frontmatterKey } from './parsers/common';
+import { frontmatterKey, kanbanDataHeadingKey } from './parsers/common';
 import {
   createSearchSelect,
   defaultDateTrigger,
@@ -90,6 +90,7 @@ export interface KanbanSettings {
   'tag-sort'?: TagSort[];
   'time-format'?: string;
   'time-trigger'?: string;
+  [kanbanDataHeadingKey]?: string;
 }
 
 export interface KanbanViewSettings {
@@ -469,6 +470,34 @@ export class SettingsManager {
           manager: this,
         })
       );
+
+    new Setting(contentEl)
+      .setName(t('Kanban Data Heading'))
+      .setDesc(
+        t(
+          local ?
+          'When set for specific board, all Kanban data will be organized under this heading in the markdown file, enabling you to include other data alongside it in the same note.' :
+          'Specifies the "kanban-data-heading" frontmatter value used when executing the "Kanban: Convert markdown note to Kanban" command, allowing you to include other information in the same note alongside the Kanban data.'
+        )
+      )
+      .addText((text) => {
+        const [value, _] = this.getSetting(kanbanDataHeadingKey, local);
+
+        text.inputEl.placeholder = '';
+        text.inputEl.value = value ? value.toString() : '';
+
+        text.onChange((val) => {
+          if (val) {
+            this.applySettingsUpdate({
+              [kanbanDataHeadingKey]: {
+                $set: val
+              },
+            });
+
+            return;
+          }
+        });
+      });
 
     contentEl.createEl('h4', { text: t('Tags') });
 

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -104,7 +104,7 @@ export class StateManager {
     const view = this.getAView();
 
     if (view) {
-      const fileStr = this.parser.boardToMd(this.state);
+      const fileStr = this.parser.boardToMd(this.state, view.data);
       view.requestSaveToDisk(fileStr);
 
       this.viewSet.forEach((view) => {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -7,6 +7,7 @@ const en = {
   'Archive completed cards in active board': 'Archive completed cards in active board',
   'Error: current file is not a Kanban board': 'Error: current file is not a Kanban board',
   'Convert empty note to Kanban': 'Convert empty note to Kanban',
+  'Convert markdown note to Kanban': 'Convert markdown note to Kanban',
   'Error: cannot create Kanban, the current note is not empty':
     'Error: cannot create Kanban, the current note is not empty',
   'New kanban board': 'New kanban board',
@@ -66,6 +67,9 @@ const en = {
   'Notes created from Kanban cards will be placed in this folder. If blank, they will be placed in the default location for this vault.':
     'Notes created from Kanban cards will be placed in this folder. If blank, they will be placed in the default location for this vault.',
   'Default folder': 'Default folder',
+  'Kanban Data Heading': 'Kanban Data Heading',
+  'When set for specific board, all Kanban data will be organized under this heading in the markdown file, enabling you to include other data alongside it in the same note.': 'When set for a specific board, all Kanban data will be organized under this heading in the markdown file, allowing you to include other data alongside it within the same note. However, if you edit the markdown of your Kanban note before setting this Kanban heading, the note will be completely overwritten, and all existing data, except for the Kanban content, will be lost. Proceed with caution to avoid accidental data loss.',
+  'Specifies the "kanban-data-heading" frontmatter value used when executing the "Kanban: Convert markdown note to Kanban" command, allowing you to include other information in the same note alongside the Kanban data.': 'Specifies the "kanban-data-heading" frontmatter value used when executing the "Kanban: Convert markdown note to Kanban" command, allowing you to include other information in the same note alongside the Kanban data.',
   'List width': 'List width',
   'Expand lists to full width in list view': 'Expand lists to full width in list view',
   'Enter a number to set the list width in pixels.':

--- a/src/parsers/List.ts
+++ b/src/parsers/List.ts
@@ -40,13 +40,13 @@ export class ListFormat implements BaseFormat {
     return updateItemContent(this.stateManager, item, content);
   }
 
-  boardToMd(board: Board) {
-    return boardToMd(board);
+  boardToMd(board: Board, originalData?: string) {
+    return boardToMd(board, this.stateManager, originalData);
   }
 
   mdToBoard(md: string) {
-    const { ast, settings, frontmatter } = parseMarkdown(this.stateManager, md);
-    const newBoard = astToUnhydratedBoard(this.stateManager, settings, frontmatter, ast, md);
+    const { ast, settings, frontmatter, operationalMd } = parseMarkdown(this.stateManager, md);
+    const newBoard = astToUnhydratedBoard(this.stateManager, settings, frontmatter, ast, operationalMd);
     const { state } = this.stateManager;
     const dv = getAPI();
 

--- a/src/parsers/common.ts
+++ b/src/parsers/common.ts
@@ -7,6 +7,7 @@ import { defaultSort } from 'src/helpers/util';
 import { t } from 'src/lang/helpers';
 
 export const frontmatterKey = 'kanban-plugin';
+export const kanbanDataHeadingKey = "kanban-data-heading";
 
 export enum ParserFormats {
   List,
@@ -15,7 +16,7 @@ export enum ParserFormats {
 export interface BaseFormat {
   newItem(content: string, checkChar: string, forceEdit?: boolean): Item;
   updateItemContent(item: Item, content: string): Item;
-  boardToMd(board: Board): string;
+  boardToMd(board: Board, originalData?: string): string;
   mdToBoard(md: string): Board;
   reparseBoard(): Board;
 }


### PR DESCRIPTION
Related issues:
- https://github.com/mgmeyers/obsidian-kanban/issues/1042
- _(somewhat related)_ https://github.com/mgmeyers/obsidian-kanban/issues/4 

## Problem

Sometimes, it’s more convenient to have a Kanban board alongside regular markdown content within the same file. For example, I often have task notes that include subtasks I’d like to track using Kanban, while keeping the task description in the same place. However, with the current implementation, I’m forced to create a separate Kanban note for each case. This results in having two notes for a single task instead of consolidating everything into one note, which feels redundant and less organized.

## Solution

This PR introduces the concept of a "Kanban Data Heading". It's a H1 heading that groups all Kanban data under itself. When defined for a Kanban note - the plugin updates only the section of the note, which corresponds to this header. It's inspired by [Obsidian Excalidraw's "Back-of-the-card" feature](https://youtu.be/P_Q6avJGoWI?si=ksqKKzVjs5fYQrrO&t=428) 

This setting is not set by default. The default behavior of the plugin is unchanged, the PR only adds this feature as an option. If user wants to enable it for a Kanban note, they can set the Kanban Data Heading in the settings of the board. Also user can "convert" their regular markdown notes to Kanban Note by executing a command "Convert markdown note to Kanban", it automatically adds a new header to the note where the kanban data is placed

Please see the video below for demonstration of the feature:

https://github.com/user-attachments/assets/5bee5136-f8e9-42f9-a425-a84d5110dbe6

Also, this allows the user to combine markdown, kanban and excalidraw all in the same note as demonstrated in the next videos:

https://github.com/user-attachments/assets/897251f6-838d-47cf-94b0-31d1c3fe2f9a


https://github.com/user-attachments/assets/dbc41cf6-e4b3-4d6a-9c1c-c04552c9d2bf


**NOTE:** While I’ve tested various use cases thoroughly, there is still a possibility that this feature could inadvertently affect your data. I strongly recommend creating a backup of your notes before using this feature, especially when enabling it for the first time.