### PR TITLE
[Feature] Add tags from header to new items created in lane

### DIFF
--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -112,38 +112,10 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
         return stateManager.setState((board) => {
           const entity = getEntityFromPath(board, dragPath);
           const newBoard: Board = moveEntity(
+            stateManager,
             board,
             dragPath,
             dropPath,
-            (entity) => {
-              if (entity.type === DataTypes.Item) {
-                const { next } = maybeCompleteForMove(
-                  stateManager,
-                  board,
-                  dragPath,
-                  stateManager,
-                  board,
-                  dropPath,
-                  entity
-                );
-                return next;
-              }
-              return entity;
-            },
-            (entity) => {
-              if (entity.type === DataTypes.Item) {
-                const { replacement } = maybeCompleteForMove(
-                  stateManager,
-                  board,
-                  dragPath,
-                  stateManager,
-                  board,
-                  dropPath,
-                  entity
-                );
-                return replacement;
-              }
-            }
           );
 
           if (entity.type === DataTypes.Lane) {

--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -286,6 +286,7 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
                       lane={data as Lane}
                       laneIndex={laneIndex}
                       isStatic={true}
+                      completedLaneIndex={null}
                       isCollapsed={!!collapseState[laneIndex]}
                       collapseDir={boardView === 'list' ? 'vertical' : 'horizontal'}
                     />
@@ -298,7 +299,7 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
               return (
                 <KanbanContext.Provider value={context}>
                   <div className={c('drag-container')} style={styles}>
-                    <DraggableItem laneTags={[]} item={data as Item} itemIndex={0} isStatic={true} />
+                    <DraggableItem completedLaneIndex={null} laneTags={[]} item={data as Item} itemIndex={0} isStatic={true} />
                   </div>
                 </KanbanContext.Provider>
               );

--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -326,7 +326,7 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
               return (
                 <KanbanContext.Provider value={context}>
                   <div className={c('drag-container')} style={styles}>
-                    <DraggableItem item={data as Item} itemIndex={0} isStatic={true} />
+                    <DraggableItem laneTags={[]} item={data as Item} itemIndex={0} isStatic={true} />
                   </div>
                 </KanbanContext.Provider>
               );

--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -153,6 +153,11 @@ export function MarkdownEditor({
                 });
                 return true;
               },
+              keydown: (evt) => {
+                if (evt.key === "Enter") {
+                  onSubmit(this.cm)
+                }
+              },
               blur: () => {
                 if (Platform.isMobile) {
                   view.contentEl.removeClass('is-mobile-editing');
@@ -191,7 +196,7 @@ export function MarkdownEditor({
             keymap.of([
               {
                 key: 'Enter',
-                run: makeEnterHandler(false, false),
+                run: (_: EditorView) => true,
                 shift: makeEnterHandler(false, true),
                 preventDefault: true,
               },

--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -153,11 +153,11 @@ export function MarkdownEditor({
                 });
                 return true;
               },
-              keydown: (evt) => {
+              keydown: Platform.isMobile ? (evt) => {
                 if (evt.key === "Enter") {
                   onSubmit(this.cm)
                 }
-              },
+              } : undefined,
               blur: () => {
                 if (Platform.isMobile) {
                   view.contentEl.removeClass('is-mobile-editing');
@@ -196,7 +196,7 @@ export function MarkdownEditor({
             keymap.of([
               {
                 key: 'Enter',
-                run: (_: EditorView) => true,
+                run: Platform.isMobile ? (_: EditorView) => true : makeEnterHandler(false, false),
                 shift: makeEnterHandler(false, true),
                 preventDefault: true,
               },

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -16,7 +16,7 @@ import { frontmatterKey } from 'src/parsers/common';
 
 import { KanbanContext, SearchContext } from '../context';
 import { c } from '../helpers';
-import { EditState, EditingState, Item, isEditing } from '../types';
+import { EditState, EditingState, Item, Lane, isEditing } from '../types';
 import { ItemCheckbox } from './ItemCheckbox';
 import { ItemContent } from './ItemContent';
 import { useItemMenu } from './ItemMenu';
@@ -27,6 +27,7 @@ import { getItemClassModifiers } from './helpers';
 export interface DraggableItemProps {
   item: Item;
   itemIndex: number;
+  laneTags: string[];
   isStatic?: boolean;
   shouldMarkItemsComplete?: boolean;
 }
@@ -34,6 +35,7 @@ export interface DraggableItemProps {
 export interface ItemInnerProps {
   item: Item;
   isStatic?: boolean;
+  laneTags: string[];
   shouldMarkItemsComplete?: boolean;
   isMatch?: boolean;
   searchQuery?: string;
@@ -42,6 +44,7 @@ export interface ItemInnerProps {
 const ItemInner = memo(function ItemInner({
   item,
   shouldMarkItemsComplete,
+  laneTags,
   isMatch,
   searchQuery,
   isStatic,
@@ -125,6 +128,7 @@ const ItemInner = memo(function ItemInner({
         />
         <ItemContent
           item={item}
+          laneTags={laneTags}
           searchQuery={isMatch ? searchQuery : undefined}
           setEditState={setEditState}
           editState={editState}
@@ -183,20 +187,21 @@ export const DraggableItem = memo(function DraggableItem(props: DraggableItemPro
 
 interface ItemsProps {
   isStatic?: boolean;
-  items: Item[];
+  lane: Lane;
   shouldMarkItemsComplete: boolean;
 }
 
-export const Items = memo(function Items({ isStatic, items, shouldMarkItemsComplete }: ItemsProps) {
+export const Items = memo(function Items({ isStatic, lane, shouldMarkItemsComplete }: ItemsProps) {
   const search = useContext(SearchContext);
   const { view } = useContext(KanbanContext);
   const boardView = view.useViewState(frontmatterKey);
 
   return (
     <>
-      {items.map((item, i) => {
+      {lane.children.map((item, i) => {
         return search?.query && !search.items.has(item) ? null : (
           <DraggableItem
+          laneTags={lane.data.tags}
             key={boardView + item.id}
             item={item}
             itemIndex={i}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -201,7 +201,7 @@ export const Items = memo(function Items({ isStatic, lane, shouldMarkItemsComple
       {lane.children.map((item, i) => {
         return search?.query && !search.items.has(item) ? null : (
           <DraggableItem
-          laneTags={lane.data.tags ?? []}
+            laneTags={lane.data.tags ?? []}
             key={boardView + item.id}
             item={item}
             itemIndex={i}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -27,6 +27,7 @@ import { getItemClassModifiers } from './helpers';
 export interface DraggableItemProps {
   item: Item;
   itemIndex: number;
+  completedLaneIndex: number | null;
   laneTags: string[];
   isStatic?: boolean;
   shouldMarkItemsComplete?: boolean;
@@ -36,6 +37,7 @@ export interface ItemInnerProps {
   item: Item;
   isStatic?: boolean;
   laneTags: string[];
+  completedLaneIndex: number | null;
   shouldMarkItemsComplete?: boolean;
   isMatch?: boolean;
   searchQuery?: string;
@@ -44,6 +46,7 @@ export interface ItemInnerProps {
 const ItemInner = memo(function ItemInner({
   item,
   shouldMarkItemsComplete,
+  completedLaneIndex,
   laneTags,
   isMatch,
   searchQuery,
@@ -124,6 +127,7 @@ const ItemInner = memo(function ItemInner({
             ? null 
             : <ItemCheckbox
               boardModifiers={boardModifiers}
+              completedLaneIndex={completedLaneIndex}
               item={item}
               path={path}
               shouldMarkItemsComplete={shouldMarkItemsComplete}
@@ -192,10 +196,11 @@ export const DraggableItem = memo(function DraggableItem(props: DraggableItemPro
 interface ItemsProps {
   isStatic?: boolean;
   lane: Lane;
+  completedLaneIndex: number | null;
   shouldMarkItemsComplete: boolean;
 }
 
-export const Items = memo(function Items({ isStatic, lane, shouldMarkItemsComplete }: ItemsProps) {
+export const Items = memo(function Items({ isStatic, lane, completedLaneIndex, shouldMarkItemsComplete }: ItemsProps) {
   const search = useContext(SearchContext);
   const { view } = useContext(KanbanContext);
   const boardView = view.useViewState(frontmatterKey);
@@ -207,6 +212,7 @@ export const Items = memo(function Items({ isStatic, lane, shouldMarkItemsComple
           <DraggableItem
             laneTags={lane.data.tags ?? []}
             key={boardView + item.id}
+            completedLaneIndex={completedLaneIndex}
             item={item}
             itemIndex={i}
             shouldMarkItemsComplete={shouldMarkItemsComplete}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -201,7 +201,7 @@ export const Items = memo(function Items({ isStatic, lane, shouldMarkItemsComple
       {lane.children.map((item, i) => {
         return search?.query && !search.items.has(item) ? null : (
           <DraggableItem
-          laneTags={lane.data.tags}
+          laneTags={lane.data.tags ?? []}
             key={boardView + item.id}
             item={item}
             itemIndex={i}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -119,13 +119,17 @@ const ItemInner = memo(function ItemInner({
       {...ignoreAttr}
     >
       <div className={c('item-title-wrapper')} {...ignoreAttr}>
-        <ItemCheckbox
-          boardModifiers={boardModifiers}
-          item={item}
-          path={path}
-          shouldMarkItemsComplete={shouldMarkItemsComplete}
-          stateManager={stateManager}
-        />
+        {
+          item.data.metadata.tags.includes("#no-checkbox") 
+            ? null 
+            : <ItemCheckbox
+              boardModifiers={boardModifiers}
+              item={item}
+              path={path}
+              shouldMarkItemsComplete={shouldMarkItemsComplete}
+              stateManager={stateManager}
+            />
+        }
         <ItemContent
           item={item}
           laneTags={laneTags}

--- a/src/components/Item/ItemCheckbox.tsx
+++ b/src/components/Item/ItemCheckbox.tsx
@@ -7,11 +7,13 @@ import { getTaskStatusDone, toggleTask } from 'src/parsers/helpers/inlineMetadat
 import { BoardModifiers } from '../../helpers/boardModifiers';
 import { Icon } from '../Icon/Icon';
 import { c } from '../helpers';
-import { Item } from '../types';
+import { Item, Lane } from '../types';
+import { moveEntity } from 'src/dnd/util/data';
 
 interface ItemCheckboxProps {
   path: Path;
   item: Item;
+  completedLaneIndex: number | null;
   shouldMarkItemsComplete: boolean;
   stateManager: StateManager;
   boardModifiers: BoardModifiers;
@@ -21,6 +23,7 @@ export const ItemCheckbox = memo(function ItemCheckbox({
   shouldMarkItemsComplete,
   path,
   item,
+  completedLaneIndex,
   stateManager,
   boardModifiers,
 }: ItemCheckboxProps) {
@@ -54,6 +57,12 @@ export const ItemCheckbox = memo(function ItemCheckbox({
           },
         })
       );
+    }
+
+    if (completedLaneIndex !== null) {
+      stateManager.setState((boardData) => {
+        return moveEntity(stateManager, boardData, path, [completedLaneIndex, 0]);
+      });
     }
   }, [item, stateManager, boardModifiers, ...path]);
 

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -305,7 +305,7 @@ export const ItemContent = memo(function ItemContent({
             getDateColor={getDateColor}
           />
           <InlineMetadata item={item} stateManager={stateManager} />
-          <Tags tags={item.data.metadata.tags.filter((tag) => !laneTags.includes(tag))} searchQuery={searchQuery} />
+          <Tags tags={item.data.metadata.tags?.filter((tag) => !(laneTags ?? []).includes(tag))} searchQuery={searchQuery} />
         </div>
       )}
     </div>

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -79,6 +79,7 @@ export interface ItemContentProps {
   item: Item;
   setEditState: Dispatch<StateUpdater<EditState>>;
   searchQuery?: string;
+  laneTags: string[];
   showMetadata?: boolean;
   editState: EditState;
   isStatic: boolean;
@@ -185,6 +186,7 @@ export const ItemContent = memo(function ItemContent({
   editState,
   setEditState,
   searchQuery,
+  laneTags,
   showMetadata = true,
   isStatic,
 }: ItemContentProps) {
@@ -303,7 +305,7 @@ export const ItemContent = memo(function ItemContent({
             getDateColor={getDateColor}
           />
           <InlineMetadata item={item} stateManager={stateManager} />
-          <Tags tags={item.data.metadata.tags} searchQuery={searchQuery} />
+          <Tags tags={item.data.metadata.tags.filter((tag) => !laneTags.includes(tag))} searchQuery={searchQuery} />
         </div>
       )}
     </div>

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -305,7 +305,7 @@ export const ItemContent = memo(function ItemContent({
             getDateColor={getDateColor}
           />
           <InlineMetadata item={item} stateManager={stateManager} />
-          <Tags tags={item.data.metadata.tags?.filter((tag) => !(laneTags ?? []).includes(tag))} searchQuery={searchQuery} />
+          <Tags tags={item.data.metadata.tags?.filter((tag) => !((laneTags ?? []).concat(["#no-checkbox"])).includes(tag))} searchQuery={searchQuery} />
         </div>
       )}
     </div>

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -27,7 +27,7 @@ export function ItemForm({ lane, addItems, editState, setEditState, hideButton }
   });
 
   const createItem = (title: string) => {
-    addItems([stateManager.getNewItem(`${title} ${lane.data.tags}`, ' ')]);
+    addItems([stateManager.getNewItem(`${title} ${lane.data.tags.join(" ")}`, ' ')]);
     const cm = editorRef.current;
     if (cm) {
       cm.dispatch({

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -7,16 +7,17 @@ import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
 import { getDropAction } from '../Editor/helpers';
 import { KanbanContext } from '../context';
 import { c } from '../helpers';
-import { EditState, EditingState, Item, isEditing } from '../types';
+import { EditState, EditingState, Item, Lane, isEditing } from '../types';
 
 interface ItemFormProps {
+  lane: Lane;
   addItems: (items: Item[]) => void;
   editState: EditState;
   setEditState: Dispatch<StateUpdater<EditState>>;
   hideButton?: boolean;
 }
 
-export function ItemForm({ addItems, editState, setEditState, hideButton }: ItemFormProps) {
+export function ItemForm({ lane, addItems, editState, setEditState, hideButton }: ItemFormProps) {
   const { stateManager } = useContext(KanbanContext);
   const editorRef = useRef<EditorView>();
 
@@ -26,7 +27,7 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
   });
 
   const createItem = (title: string) => {
-    addItems([stateManager.getNewItem(title, ' ')]);
+    addItems([stateManager.getNewItem(`${title} ${lane.data.tags}`, ' ')]);
     const cm = editorRef.current;
     if (cm) {
       cm.dispatch({

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -27,7 +27,7 @@ export function ItemForm({ lane, addItems, editState, setEditState, hideButton }
   });
 
   const createItem = (title: string) => {
-    addItems([stateManager.getNewItem(`${title} ${lane.data.tags.join(" ")}`, ' ')]);
+    addItems([stateManager.getNewItem(`${lane.data.tags.join(" ")} ${title}`, ' ')]);
     const cm = editorRef.current;
     if (cm) {
       cm.dispatch({

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -277,7 +277,7 @@ export function useItemMenu({
               .onClick(() => {
                 if (path[0] === i) return;
                 stateManager.setState((boardData) => {
-                  return moveEntity(boardData, path, [i, 0]);
+                  return moveEntity(stateManager, boardData, path, [i, 0]);
                 });
               })
           );

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -26,6 +26,7 @@ const laneAccepts = [DataTypes.Item];
 
 export interface DraggableLaneProps {
   lane: Lane;
+  completedLaneIndex: number | null;
   laneIndex: number;
   isStatic?: boolean;
   collapseDir: 'horizontal' | 'vertical';
@@ -36,6 +37,7 @@ function DraggableLaneRaw({
   isStatic,
   lane,
   laneIndex,
+  completedLaneIndex,
   collapseDir,
   isCollapsed = false,
 }: DraggableLaneProps) {
@@ -194,6 +196,7 @@ function DraggableLaneRaw({
                   <SortableComponent onSortChange={setIsSorting} axis="vertical">
                     <Items
                       lane={lane}
+                      completedLaneIndex={completedLaneIndex}
                       isStatic={isStatic}
                       shouldMarkItemsComplete={shouldMarkItemsComplete}
                     />
@@ -229,6 +232,7 @@ function LanesRaw({ lanes, collapseDir }: LanesProps) {
   const { view } = useContext(KanbanContext);
   const boardView = view.useViewState(frontmatterKey) || 'board';
   const collapseState = view.useViewState('list-collapse') || [];
+  const completedLaneIndex: number | null =  lanes.findIndex((lane) => lane.data.shouldMarkItemsComplete === true) || null
 
   return (
     <>
@@ -238,6 +242,7 @@ function LanesRaw({ lanes, collapseDir }: LanesProps) {
             collapseDir={collapseDir}
             isCollapsed={(search?.query && !search.lanes.has(lane)) || !!collapseState[i]}
             key={boardView + lane.id}
+            completedLaneIndex={completedLaneIndex}
             lane={lane}
             laneIndex={i}
           />

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -193,7 +193,7 @@ function DraggableLaneRaw({
                 >
                   <SortableComponent onSortChange={setIsSorting} axis="vertical">
                     <Items
-                      items={lane.children}
+                      lane={lane}
                       isStatic={isStatic}
                       shouldMarkItemsComplete={shouldMarkItemsComplete}
                     />

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -168,6 +168,7 @@ function DraggableLaneRaw({
 
             {!search?.query && !isCollapsed && shouldPrepend && (
               <ItemForm
+                lane={lane}
                 addItems={addItems}
                 hideButton={isCompactPrepend}
                 editState={editState}
@@ -207,7 +208,7 @@ function DraggableLaneRaw({
             )}
 
             {!search?.query && !isCollapsed && !shouldPrepend && (
-              <ItemForm addItems={addItems} editState={editState} setEditState={setEditState} />
+              <ItemForm lane={lane} addItems={addItems} editState={editState} setEditState={setEditState} />
             )}
           </CollapsedDropArea>
         </div>

--- a/src/components/Lane/LaneHeader.tsx
+++ b/src/components/Lane/LaneHeader.tsx
@@ -106,13 +106,14 @@ export const LaneHeader = memo(function LaneHeader({
 
   const onLaneTitleChange = useCallback(
     (str: string) => {
-      const { title, maxItems } = parseLaneTitle(str);
+      const { title, maxItems, tags } = parseLaneTitle(str);
       boardModifiers.updateLane(
         lanePath,
         update(lane, {
           data: {
             title: { $set: title },
             maxItems: { $set: maxItems },
+            tags: { $set: tags },
           },
         })
       );
@@ -146,6 +147,7 @@ export const LaneHeader = memo(function LaneHeader({
           id={lane.id}
           editState={editState}
           maxItems={lane.data.maxItems}
+          tags={lane.data.tags}
           onChange={onLaneTitleChange}
           setEditState={setEditState}
           title={lane.data.title}

--- a/src/components/Lane/LaneTitle.tsx
+++ b/src/components/Lane/LaneTitle.tsx
@@ -1,7 +1,7 @@
 import { EditorView, ViewUpdate } from '@codemirror/view';
 import classcat from 'classcat';
 import { Dispatch, StateUpdater, useCallback, useContext, useEffect, useRef } from 'preact/hooks';
-import { laneTitleWithMaxItems } from 'src/helpers';
+import { laneTitleWithMaxItemsAndTags } from 'src/helpers';
 
 import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
@@ -12,6 +12,7 @@ import { EditState, EditingState, isEditing } from '../types';
 export interface LaneTitleProps {
   title: string;
   maxItems?: number;
+  tags: string[];
   editState: EditState;
   setEditState: Dispatch<StateUpdater<EditState>>;
   onChange: (str: string) => void;
@@ -52,7 +53,7 @@ export function LaneLimitCounter({
   );
 }
 
-export function LaneTitle({ maxItems, editState, setEditState, title, onChange }: LaneTitleProps) {
+export function LaneTitle({ maxItems, tags, editState, setEditState, title, onChange }: LaneTitleProps) {
   const { stateManager } = useContext(KanbanContext);
   const titleRef = useRef<string | null>(null);
 
@@ -92,7 +93,7 @@ export function LaneTitle({ maxItems, editState, setEditState, title, onChange }
           onEnter={onEnter}
           onEscape={onEscape}
           onSubmit={onSubmit}
-          value={laneTitleWithMaxItems(title, maxItems)}
+          value={laneTitleWithMaxItemsAndTags(title, tags, maxItems)}
         />
       ) : (
         <div className={c('lane-title-text')}>

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -101,7 +101,7 @@ export const ItemCell = memo(
             <ItemContent
               editState={editState}
               item={item}
-              laneTags={lane.data.tags}
+              laneTags={lane.data.tags ?? []}
               setEditState={setEditState}
               showMetadata={false}
               searchQuery={search?.query}

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -101,6 +101,7 @@ export const ItemCell = memo(
             <ItemContent
               editState={editState}
               item={item}
+              laneTags={lane.data.tags}
               setEditState={setEditState}
               showMetadata={false}
               searchQuery={search?.query}

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -142,7 +142,7 @@ export const LaneCell = memo(function LaneCell({ lane, path }: { lane: Lane; pat
                   if (lane === l) return;
                   stateManager.setState((boardData) => {
                     const target = boardData.children[i];
-                    return moveEntity(boardData, path, [i, target.children.length]);
+                    return moveEntity(stateManager, boardData, path, [i, target.children.length]);
                   });
                 })
             );

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -95,6 +95,7 @@ export const ItemCell = memo(
               boardModifiers={boardModifiers}
               item={item}
               path={path}
+              completedLaneIndex={null}
               shouldMarkItemsComplete={shouldMarkItemsComplete}
               stateManager={stateManager}
             />

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -17,6 +17,7 @@ export interface LaneData {
   shouldMarkItemsComplete?: boolean;
   title: string;
   maxItems?: number;
+  tags: string[];
   dom?: HTMLDivElement;
   forceEditMode?: boolean;
   sorted?: LaneSort | string;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -63,6 +63,5 @@ export function hasFrontmatterKey(file: TFile) {
 }
 
 export function laneTitleWithMaxItemsAndTags(title: string, tags: string[], maxItems?: number ) {
-  if (!maxItems) return title;
   return `${title} ${tags.join(" ")} ${maxItems ? `(${maxItems})` : ""}`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -62,7 +62,7 @@ export function hasFrontmatterKey(file: TFile) {
   return !!cache?.frontmatter?.[frontmatterKey];
 }
 
-export function laneTitleWithMaxItems(title: string, maxItems?: number) {
+export function laneTitleWithMaxItemsAndTags(title: string, tags: string[], maxItems?: number ) {
   if (!maxItems) return title;
-  return `${title} (${maxItems})`;
+  return `${title} ${tags.join(" ")} ${maxItems ? `(${maxItems})` : ""}`;
 }

--- a/src/helpers/boardModifiers.ts
+++ b/src/helpers/boardModifiers.ts
@@ -80,14 +80,14 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     moveItemToTop: (path: Path) => {
-      stateManager.setState((boardData) => moveEntity(boardData, path, [path[0], 0]));
+      stateManager.setState((boardData) => moveEntity(stateManager, boardData, path, [path[0], 0]));
     },
 
     moveItemToBottom: (path: Path) => {
       stateManager.setState((boardData) => {
         const laneIndex = path[0];
         const lane = boardData.children[laneIndex];
-        return moveEntity(boardData, path, [laneIndex, lane.children.length]);
+        return moveEntity(stateManager, boardData, path, [laneIndex, lane.children.length]);
       });
     },
 

--- a/src/parsers/formats/list.ts
+++ b/src/parsers/formats/list.ts
@@ -15,7 +15,7 @@ import {
   Lane,
   LaneTemplate,
 } from 'src/components/types';
-import { laneTitleWithMaxItems } from 'src/helpers';
+import { laneTitleWithMaxItemsAndTags } from 'src/helpers';
 import { defaultSort } from 'src/helpers/util';
 import { t } from 'src/lang/helpers';
 import { visit } from 'unist-util-visit';
@@ -407,7 +407,7 @@ function itemToMd(item: Item) {
 function laneToMd(lane: Lane) {
   const lines: string[] = [];
 
-  lines.push(`## ${replaceNewLines(laneTitleWithMaxItems(lane.data.title, lane.data.maxItems))}`);
+  lines.push(`## ${replaceNewLines(laneTitleWithMaxItemsAndTags(lane.data.title, lane.data.tags, lane.data.maxItems))}`);
 
   lines.push('');
 

--- a/src/parsers/helpers/parser.ts
+++ b/src/parsers/helpers/parser.ts
@@ -60,8 +60,10 @@ export function dedentNewLines(str: string) {
 export function parseLaneTitle(str: string) {
   str = replaceBrs(str);
 
+  const tags = (str.match(/#\w+/g) || []);
+  str = str.replace(/#\w+/g, '').trim();
   const match = str.match(/^(.*?)\s*\((\d+)\)$/);
-  if (match == null) return { title: str, maxItems: 0 };
+  if (match == null) return { title: str, maxItems: 0, tags };
 
-  return { title: match[1], maxItems: Number(match[2]) };
+  return { title: match[1], maxItems: Number(match[2]), tags };
 }

--- a/src/styles.less
+++ b/src/styles.less
@@ -667,6 +667,26 @@ button.kanban-plugin__lane-settings-button + button.kanban-plugin__lane-settings
   display: none;
 }
 
+body.is-mobile .kanban-plugin__lane-wrapper {
+  width: 90vw;
+  margin-inline-end: 0px;
+}
+
+body.is-mobile .kanban-plugin__board>div {
+  grid-template-rows: 50% 50%;
+  grid-auto-flow: column;
+  overflow-x: scroll;
+  gap: 10px;
+  display: grid;
+  width: 100%;
+  height: 100%;
+}
+
+body.is-mobile .kanban-plugin__lane-items {
+  height: 100%;
+  overflow: scroll;
+}
+
 button.kanban-plugin__new-item-button {
   background-color: transparent;
   color: var(--text-muted);


### PR DESCRIPTION
### Goal or desired outcome of this feature
Whenever there are tags in the kanban lane header, they will be added to any newly created items in that lane

### Describe the feature

If any tags are added to any lane header in a kanban board
they will not be visible when not actively editing the header
and the tags will be automatically appended to any new list items

### Screenshots, mockups, or videos
Add tags to any lane header
![image](https://github.com/user-attachments/assets/5d6e3dc9-f4ce-4f8e-a3ca-be0e45df89e1)

The tags are not shown when not actively editing
![image](https://github.com/user-attachments/assets/7811f640-b52d-4304-a07a-ab3cbf635cd4)

Any newly added items to that lane automatically have the tags added to them
![image](https://github.com/user-attachments/assets/0e91c62d-6994-4250-b1ca-bb4cc1f795c1)
