### PR TITLE
Add Custom Task Icons for Kanban Columns

### DIFF
--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -54,9 +54,12 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
         try {
           const items: Item[] = data.content.map((title: string) => {
             let item = stateManager.getNewItem(title, ' ');
+            const autoSymbol = destinationParent?.data?.autoSetTaskSymbol;
             const isComplete = !!destinationParent?.data?.shouldMarkItemsComplete;
 
-            if (isComplete) {
+            if (autoSymbol) {
+              item = update(item, { data: { checkChar: { $set: autoSymbol } } });
+            } else if (isComplete) {
               item = update(item, { data: { checkChar: { $set: getTaskStatusPreDone() } } });
               const updates = toggleTask(item, stateManager.file);
               if (updates) {
@@ -73,7 +76,9 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
                   $set: !!destinationParent?.data?.shouldMarkItemsComplete,
                 },
                 checkChar: {
-                  $set: destinationParent?.data?.shouldMarkItemsComplete
+                  $set: autoSymbol
+                    ? autoSymbol
+                    : destinationParent?.data?.shouldMarkItemsComplete
                     ? getTaskStatusDone()
                     : ' ',
                 },
@@ -84,7 +89,6 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
           return stateManager.setState((board) => insertEntity(board, dropPath, items));
         } catch (e) {
           stateManager.setError(e);
-          console.error(e);
         }
 
         return;

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -16,7 +16,7 @@ import { frontmatterKey } from 'src/parsers/common';
 
 import { KanbanContext, SearchContext } from '../context';
 import { c } from '../helpers';
-import { EditState, EditingState, Item, isEditing } from '../types';
+import { EditState, EditingState, Item, Lane, isEditing } from '../types';
 import { ItemCheckbox } from './ItemCheckbox';
 import { ItemContent } from './ItemContent';
 import { useItemMenu } from './ItemMenu';
@@ -29,6 +29,7 @@ export interface DraggableItemProps {
   itemIndex: number;
   isStatic?: boolean;
   shouldMarkItemsComplete?: boolean;
+  lane?: Lane;
 }
 
 export interface ItemInnerProps {
@@ -142,12 +143,12 @@ export const DraggableItem = memo(function DraggableItem(props: DraggableItemPro
   const measureRef = useRef<HTMLDivElement>(null);
   const search = useContext(SearchContext);
 
-  const { itemIndex, ...innerProps } = props;
+  const { itemIndex, lane, ...innerProps } = props;
 
   const bindHandle = useDragHandle(measureRef, measureRef);
 
   const isMatch = search?.query ? innerProps.item.data.titleSearch.includes(search.query) : false;
-  const classModifiers: string[] = getItemClassModifiers(innerProps.item);
+  const classModifiers: string[] = getItemClassModifiers(innerProps.item, lane);
 
   return (
     <div
@@ -185,9 +186,10 @@ interface ItemsProps {
   isStatic?: boolean;
   items: Item[];
   shouldMarkItemsComplete: boolean;
+  lane?: Lane;
 }
 
-export const Items = memo(function Items({ isStatic, items, shouldMarkItemsComplete }: ItemsProps) {
+export const Items = memo(function Items({ isStatic, items, shouldMarkItemsComplete, lane }: ItemsProps) {
   const search = useContext(SearchContext);
   const { view } = useContext(KanbanContext);
   const boardView = view.useViewState(frontmatterKey);
@@ -202,6 +204,7 @@ export const Items = memo(function Items({ isStatic, items, shouldMarkItemsCompl
             itemIndex={i}
             shouldMarkItemsComplete={shouldMarkItemsComplete}
             isStatic={isStatic}
+            lane={lane}
           />
         );
       })}

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -14,9 +14,10 @@ interface ItemFormProps {
   editState: EditState;
   setEditState: Dispatch<StateUpdater<EditState>>;
   hideButton?: boolean;
+  defaultCheckChar?: string;
 }
 
-export function ItemForm({ addItems, editState, setEditState, hideButton }: ItemFormProps) {
+export function ItemForm({ addItems, editState, setEditState, hideButton, defaultCheckChar = ' ' }: ItemFormProps) {
   const { stateManager } = useContext(KanbanContext);
   const editorRef = useRef<EditorView>();
 
@@ -26,7 +27,10 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
   });
 
   const createItem = (title: string) => {
-    addItems([stateManager.getNewItem(title, ' ')]);
+    const newItem = stateManager.getNewItem(title, defaultCheckChar);
+    addItems([newItem]);
+    
+    // Force UI update to ensure correct checkChar display
     const cm = editorRef.current;
     if (cm) {
       cm.dispatch({

--- a/src/components/Item/helpers.ts
+++ b/src/components/Item/helpers.ts
@@ -10,7 +10,7 @@ import { getDefaultLocale } from '../Editor/datePickerLocale';
 import flatpickr from '../Editor/flatpickr';
 import { Instance } from '../Editor/flatpickr/types/instance';
 import { c, escapeRegExpStr } from '../helpers';
-import { Item } from '../types';
+import { Item, Lane } from '../types';
 
 export function constructDatePicker(
   win: Window,
@@ -273,7 +273,7 @@ export function constructMenuTimePickerOnChange({
   };
 }
 
-export function getItemClassModifiers(item: Item) {
+export function getItemClassModifiers(item: Item, lane?: Lane) {
   const date = item.data.metadata.date;
   const classModifiers: string[] = [];
 
@@ -291,7 +291,10 @@ export function getItemClassModifiers(item: Item) {
     }
   }
 
-  if (item.data.checked && item.data.checkChar === getTaskStatusDone()) {
+  const isStandardComplete = item.data.checked && item.data.checkChar === getTaskStatusDone();
+  const hasCustomSymbol = lane?.data.autoSetTaskSymbol && item.data.checkChar === lane.data.autoSetTaskSymbol;
+  
+  if (isStandardComplete || hasCustomSymbol) {
     classModifiers.push('is-complete');
   }
 

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -91,7 +91,11 @@ function DraggableLaneRaw({
                 $set: shouldMarkItemsComplete,
               },
               checkChar: {
-                $set: shouldMarkItemsComplete ? getTaskStatusDone() : ' ',
+                $set: lane.data.autoSetTaskSymbol
+                  ? lane.data.autoSetTaskSymbol
+                  : shouldMarkItemsComplete
+                  ? getTaskStatusDone()
+                  : ' ',
               },
             },
           })
@@ -168,7 +172,10 @@ function DraggableLaneRaw({
 
             {!search?.query && !isCollapsed && shouldPrepend && (
               <ItemForm
-                addItems={addItems}
+                addItems={(items) => {
+                  const symbol = lane.data.autoSetTaskSymbol || (shouldMarkItemsComplete ? getTaskStatusDone() : ' ');
+                  addItems(items.map(item => update(item, { data: { checkChar: { $set: symbol } } })));
+                }}
                 hideButton={isCompactPrepend}
                 editState={editState}
                 setEditState={setEditState}
@@ -195,6 +202,7 @@ function DraggableLaneRaw({
                       items={lane.children}
                       isStatic={isStatic}
                       shouldMarkItemsComplete={shouldMarkItemsComplete}
+                      lane={lane}
                     />
                     <SortPlaceholder
                       accepts={laneAccepts}
@@ -207,7 +215,14 @@ function DraggableLaneRaw({
             )}
 
             {!search?.query && !isCollapsed && !shouldPrepend && (
-              <ItemForm addItems={addItems} editState={editState} setEditState={setEditState} />
+              <ItemForm
+                addItems={(items) => {
+                  const symbol = lane.data.autoSetTaskSymbol || (shouldMarkItemsComplete ? getTaskStatusDone() : ' ');
+                  addItems(items.map(item => update(item, { data: { checkChar: { $set: symbol } } })));
+                }}
+                editState={editState}
+                setEditState={setEditState}
+              />
             )}
           </CollapsedDropArea>
         </div>

--- a/src/components/Lane/LaneForm.tsx
+++ b/src/components/Lane/LaneForm.tsx
@@ -14,7 +14,7 @@ interface LaneFormProps {
   closeLaneForm: () => void;
 }
 
-export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
+export function LaneForm ({ onNewLane, closeLaneForm }: LaneFormProps) {
   const [shouldMarkAsComplete, setShouldMarkAsComplete] = useState(false);
   const [autoSetTaskSymbol, setAutoSetTaskSymbol] = useState('');
   const editorRef = useRef<EditorView>();
@@ -91,16 +91,16 @@ export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
           className={`checkbox-container ${shouldMarkAsComplete ? 'is-enabled' : ''}`}
         />
       </div>
-      <div className={c('input-wrapper')} style={{marginTop: 12}}>
-        <div className={c('checkbox-label')}>任务符号（拖拽到本列时自动设置）</div>
+      <div className={c('input-wrapper')}>
+        <div className={c('checkbox-label')}>{t('Task symbol')}</div>
         <input
           type="text"
           value={autoSetTaskSymbol}
           maxLength={2}
-          placeholder="如 /, -, > 等"
+          placeholder={t('Task symbol placeholder')}
           onInput={e => setAutoSetTaskSymbol((e.target as HTMLInputElement).value)}
           className={c('lane-symbol-input')}
-          style={{width: 60, marginTop: 4}}
+          style={{ width: '100%', marginTop: 4 }}
         />
       </div>
       <div className={c('lane-input-actions')}>

--- a/src/components/Lane/LaneForm.tsx
+++ b/src/components/Lane/LaneForm.tsx
@@ -16,6 +16,7 @@ interface LaneFormProps {
 
 export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
   const [shouldMarkAsComplete, setShouldMarkAsComplete] = useState(false);
+  const [autoSetTaskSymbol, setAutoSetTaskSymbol] = useState('');
   const editorRef = useRef<EditorView>();
   const inputRef = useRef<HTMLTextAreaElement>();
   const clickOutsideRef = useOnclickOutside(() => closeLaneForm(), {
@@ -37,6 +38,7 @@ export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
         data: {
           ...parseLaneTitle(title),
           shouldMarkItemsComplete: shouldMarkAsComplete,
+          autoSetTaskSymbol: autoSetTaskSymbol || undefined,
         },
       });
 
@@ -49,9 +51,10 @@ export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
       });
 
       setShouldMarkAsComplete(false);
+      setAutoSetTaskSymbol('');
       onNewLane();
     },
-    [onNewLane, setShouldMarkAsComplete, boardModifiers]
+    [onNewLane, setShouldMarkAsComplete, setAutoSetTaskSymbol, boardModifiers, autoSetTaskSymbol]
   );
 
   const editState = useMemo(() => ({ x: 0, y: 0 }), []);
@@ -86,6 +89,18 @@ export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
         <div
           onClick={() => setShouldMarkAsComplete(!shouldMarkAsComplete)}
           className={`checkbox-container ${shouldMarkAsComplete ? 'is-enabled' : ''}`}
+        />
+      </div>
+      <div className={c('input-wrapper')} style={{marginTop: 12}}>
+        <div className={c('checkbox-label')}>任务符号（拖拽到本列时自动设置）</div>
+        <input
+          type="text"
+          value={autoSetTaskSymbol}
+          maxLength={2}
+          placeholder="如 /, -, > 等"
+          onInput={e => setAutoSetTaskSymbol((e.target as HTMLInputElement).value)}
+          className={c('lane-symbol-input')}
+          style={{width: 60, marginTop: 4}}
         />
       </div>
       <div className={c('lane-input-actions')}>

--- a/src/components/Lane/LaneSettings.tsx
+++ b/src/components/Lane/LaneSettings.tsx
@@ -34,6 +34,24 @@ export function LaneSettings({ lane, lanePath, editState }: LaneSettingsProps) {
           className={`checkbox-container ${lane.data.shouldMarkItemsComplete ? 'is-enabled' : ''}`}
         />
       </div>
+      <div className={c('input-wrapper')} style={{marginTop: 12}}>
+        <div className={c('checkbox-label')}>任务符号（拖拽到本列时自动设置）</div>
+        <input
+          type="text"
+          value={lane.data.autoSetTaskSymbol || ''}
+          maxLength={2}
+          placeholder="如 /, -, > 等"
+          onInput={e => {
+            const value = (e.target as HTMLInputElement).value;
+            boardModifiers.updateLane(
+              lanePath,
+              update(lane, { data: { autoSetTaskSymbol: { $set: value } } })
+            );
+          }}
+          className={c('lane-symbol-input')}
+          style={{width: 60, marginTop: 4}}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/Lane/LaneSettings.tsx
+++ b/src/components/Lane/LaneSettings.tsx
@@ -13,7 +13,7 @@ export interface LaneSettingsProps {
   editState: EditState;
 }
 
-export function LaneSettings({ lane, lanePath, editState }: LaneSettingsProps) {
+export function LaneSettings ({ lane, lanePath, editState }: LaneSettingsProps) {
   const { boardModifiers } = useContext(KanbanContext);
 
   if (!isEditing(editState)) return null;
@@ -34,13 +34,13 @@ export function LaneSettings({ lane, lanePath, editState }: LaneSettingsProps) {
           className={`checkbox-container ${lane.data.shouldMarkItemsComplete ? 'is-enabled' : ''}`}
         />
       </div>
-      <div className={c('input-wrapper')} style={{marginTop: 12}}>
-        <div className={c('checkbox-label')}>任务符号（拖拽到本列时自动设置）</div>
+      <div className={c('input-wrapper')}>
+        <div className={c('checkbox-label')}>{t('Task symbol')}</div>
         <input
           type="text"
           value={lane.data.autoSetTaskSymbol || ''}
           maxLength={2}
-          placeholder="如 /, -, > 等"
+          placeholder={t('Task symbol placeholder')}
           onInput={e => {
             const value = (e.target as HTMLInputElement).value;
             boardModifiers.updateLane(
@@ -49,7 +49,7 @@ export function LaneSettings({ lane, lanePath, editState }: LaneSettingsProps) {
             );
           }}
           className={c('lane-symbol-input')}
-          style={{width: 60, marginTop: 4}}
+          style={{ width: '100%', marginTop: 4 }}
         />
       </div>
     </div>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -20,6 +20,7 @@ export interface LaneData {
   dom?: HTMLDivElement;
   forceEditMode?: boolean;
   sorted?: LaneSort | string;
+  autoSetTaskSymbol?: string;
 }
 
 export interface DataKey {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -242,6 +242,8 @@ const en = {
   'Mark cards in this list as complete': 'Mark cards in this list as complete',
   'Add list': 'Add list',
   'Add a list': 'Add a list',
+  'Task symbol': 'Task symbol (auto-set when dragging to this list)',
+  'Task symbol placeholder': 'e.g. /, -, > etc.',
 
   // components/Lane/LaneHeader.tsx
   'Move list': 'Move list',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -162,6 +162,8 @@ const lang: Partial<Lang> = {
   'Mark cards in this list as complete': '将该列设置为完成列',
   'Add list': '添加',
   'Add a list': '添加列',
+  'Task symbol': '任务符号（拖拽到本列时自动设置）',
+  'Task symbol placeholder': '如 /, -, > 等',
 
   // components/Lane/LaneHeader.tsx
   'Move list': '移动列',

--- a/src/parsers/formats/list.ts
+++ b/src/parsers/formats/list.ts
@@ -237,6 +237,30 @@ function isArchiveLane(child: Content, children: Content[], currentIndex: number
   return prev && prev.type === 'thematicBreak';
 }
 
+function parseLaneExtra(str: string) {
+  const obsidianMatch = str.match(/%%\s*kanban-column:\s*symbol=(.+?)\s*%%/);
+  if (obsidianMatch) {
+    return { autoSetTaskSymbol: obsidianMatch[1].trim() };
+  }
+  
+  return {};
+}
+
+function findColumnConfigFromNode(node: any): string | null {
+  if (node.type === 'html' && node.value) {
+    return node.value;
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      const result = findColumnConfigFromNode(child);
+      if (result) return result;
+    }
+  }
+  
+  return null;
+}
+
 export function astToUnhydratedBoard(
   stateManager: StateManager,
   settings: KanbanSettings,
@@ -253,23 +277,50 @@ export function astToUnhydratedBoard(
       const title = getStringFromBoundary(md, headingBoundary);
 
       let shouldMarkItemsComplete = false;
+      let autoSetTaskSymbol;
+
+      for (let i = index + 1; i < root.children.length; i++) {
+        const nextChild = root.children[i];
+        if (nextChild.type === 'heading') break;
+        
+        if (nextChild.type === 'paragraph') {
+          const paraStr = toString(nextChild);
+          
+          const extra = parseLaneExtra(paraStr);
+          if (extra.autoSetTaskSymbol) {
+            autoSetTaskSymbol = extra.autoSetTaskSymbol;
+          }
+          
+          if (paraStr === t('Complete')) {
+            shouldMarkItemsComplete = true;
+          }
+        }
+        
+        if (nextChild.type === 'html') {
+          const commentStr = nextChild.value || '';
+          const extra = parseLaneExtra(commentStr);
+          if (extra.autoSetTaskSymbol) {
+            autoSetTaskSymbol = extra.autoSetTaskSymbol;
+          }
+        }
+        
+        const commentStr = findColumnConfigFromNode(nextChild);
+        if (commentStr) {
+          const extra = parseLaneExtra(commentStr);
+          if (extra.autoSetTaskSymbol) {
+            autoSetTaskSymbol = extra.autoSetTaskSymbol;
+          }
+        }
+      }
 
       const list = getNextOfType(root.children, index, 'list', (child) => {
         if (child.type === 'heading') return false;
-
         if (child.type === 'paragraph') {
           const childStr = toString(child);
-
           if (childStr.startsWith('%% kanban:settings')) {
             return false;
           }
-
-          if (childStr === t('Complete')) {
-            shouldMarkItemsComplete = true;
-            return true;
-          }
         }
-
         return true;
       });
 
@@ -287,15 +338,18 @@ export function astToUnhydratedBoard(
         return;
       }
 
+      const laneData = {
+        ...parseLaneTitle(title),
+        shouldMarkItemsComplete,
+        autoSetTaskSymbol,
+      };
+
       if (!list) {
         lanes.push({
           ...LaneTemplate,
           children: [],
           id: generateInstanceId(),
-          data: {
-            ...parseLaneTitle(title),
-            shouldMarkItemsComplete,
-          },
+          data: laneData,
         });
       } else {
         lanes.push({
@@ -309,10 +363,7 @@ export function astToUnhydratedBoard(
             };
           }),
           id: generateInstanceId(),
-          data: {
-            ...parseLaneTitle(title),
-            shouldMarkItemsComplete,
-          },
+          data: laneData,
         });
       }
     }
@@ -346,7 +397,7 @@ export function updateItemContent(stateManager: StateManager, oldItem: Item, new
   try {
     hydrateItem(stateManager, newItem);
   } catch (e) {
-    console.error(e);
+    stateManager.setError(e);
   }
 
   return newItem;
@@ -373,7 +424,7 @@ export function newItem(
   try {
     hydrateItem(stateManager, newItem);
   } catch (e) {
-    console.error(e);
+    stateManager.setError(e);
   }
 
   return newItem;
@@ -409,7 +460,10 @@ function laneToMd(lane: Lane) {
 
   lines.push(`## ${replaceNewLines(laneTitleWithMaxItems(lane.data.title, lane.data.maxItems))}`);
 
-  lines.push('');
+  if (lane.data.autoSetTaskSymbol) {
+    lines.push(`%% kanban-column: symbol=${lane.data.autoSetTaskSymbol} %%`);
+    lines.push('');
+  }
 
   if (lane.data.shouldMarkItemsComplete) {
     lines.push(completeString);


### PR DESCRIPTION
Demo:

https://github.com/user-attachments/assets/6e4be553-73d4-4553-a928-d4e9ca2f3aab


## Features
- Allow setting custom task symbols for each Kanban column (max 2 characters)
- Automatically apply the symbol when cards are dragged to columns with custom task symbols
- Added custom styles and icons for common symbols (e.g., /, -, >)

## Discussions
https://github.com/mgmeyers/obsidian-kanban/discussions/1056 https://github.com/mgmeyers/obsidian-kanban/discussions/1108

## Internationalization
- Added translations for both English and Chinese

## Technical Details
```md
## Close
%% kanban-column: symbol=- %%

- [-] Todo
- [-] World


## Done
%% kanban-column: symbol=? %%

**完成**
- [?] Close ✅ 2025-06-12
```