### PR TITLE
Reduce Scaling Modifier for Drag & Drop Scroll Speed

### DIFF
--- a/src/dnd/managers/ScrollManager.ts
+++ b/src/dnd/managers/ScrollManager.ts
@@ -23,7 +23,7 @@ export type IntersectionObserverHandler = (entry: IntersectionObserverEntry) => 
 
 export const scrollContainerEntityType = 'scroll-container';
 
-const scrollStrengthModifier = 8;
+const scrollStrengthModifier = 1;
 
 const sides: Side[] = ['top', 'right', 'bottom', 'left'];
 


### PR DESCRIPTION
Resolves #1110 by reducing the scaling factor applied to drag-and-drop scrolling animation.  This allows dragged elements to be more easily moved from one lane into an adjacent one off the edge of the screen without overshooting to max scroll position, especially on a touchscreen mobile device.  Does not change the activation threshold distance from the frame edge for scrolling (35 pixels?) but effectively ramps scrolling speed 8x slower as the draggable element is moved closer to the frame edge.

Not tested on a mobile device.  One theory as to why some users find this more bothersome than others.  If a user is on a larger display resolution (4k, 1440p, etc) they may have display scaling active.  In this case, the display scaling factor has the effect making the drag scrolling calculation more sensitive (larger pixel displacement of the element for the same physical mouse movement).