### PR TITLE
Adds menu option to move card to next list (#1141)

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -265,6 +265,23 @@ export function useItemMenu({
 
       menu.addSeparator();
 
+      function addMoveToNextLaneOption(menu: Menu) {
+        const lanes = stateManager.state.children;
+        if (lanes.length <= 1) return;
+        if (path[0] == lanes.length - 1) return;
+        menu.addItem((i) => {
+          i.setIcon('lucide-arrow-right')
+            .setTitle(t('Move to next list'))
+            .onClick(() => {
+              stateManager.setState((boardData) => {
+                return moveEntity(boardData, path, [path[0] + 1, 0]);
+              });
+            });
+        });
+      }
+
+      addMoveToNextLaneOption(menu);
+
       const addMoveToOptions = (menu: Menu) => {
         const lanes = stateManager.state.children;
         if (lanes.length <= 1) return;

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -235,6 +235,7 @@ const en = {
   'Add label': 'Add label',
   'Move to top': 'Move to top',
   'Move to bottom': 'Move to bottom',
+  'Move to next list': 'Move to next list',
   'Move to list': 'Move to list',
 
   // components/Lane/LaneForm.tsx


### PR DESCRIPTION
(Fixes #1141) 
Adds a menu option in cards menu to move the corresponding card to next list.


https://github.com/user-attachments/assets/e67012ed-030e-4061-aff0-a59433ade3f7

