### PR TITLE
Fix keyboard shortcuts broken after adding new cards

### DIFF
--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -249,17 +249,22 @@ export function MarkdownEditor({
     return () => {
       if (Platform.isMobile) {
         cm.dom.win.removeEventListener('keyboardDidShow', onShow);
-
-        if (view.activeEditor === controller) {
-          view.activeEditor = null;
-        }
-
-        if (app.workspace.activeEditor === controller) {
-          app.workspace.activeEditor = null;
-          (app as any).mobileToolbar.update();
-          view.contentEl.removeClass('is-mobile-editing');
-        }
       }
+
+      // Clean up activeEditor references on all platforms
+      if (view.activeEditor === controller) {
+        view.activeEditor = null;
+      }
+
+      if (app.workspace.activeEditor === controller) {
+        app.workspace.activeEditor = null;
+      }
+
+      if (Platform.isMobile) {
+        (app as any).mobileToolbar.update();
+        view.contentEl.removeClass('is-mobile-editing');
+      }
+
       view.plugin.removeChild(editor);
       internalRef.current = null;
       if (editorRef) editorRef.current = null;


### PR DESCRIPTION
### Fix keyboard shortcuts broken after adding new cards

#### Problem
After adding a new card to the Kanban board, keyboard shortcuts in other parts of the application (such as navigating to links under the cursor) would stop working. This was caused by improper cleanup of editor context references.

#### Solution
- Added proper cleanup of `activeEditor` references in the `MarkdownEditor` component’s `useEffect` cleanup function.
- Ensured both `view.activeEditor` and `app.workspace.activeEditor` are properly nullified when the editor is unmounted.
- This prevents stale editor references from interfering with keyboard shortcuts in other parts of the application.

#### Changes
- Modified the cleanup function in `MarkdownEditor.tsx` to properly reset editor references on all platforms.
- Maintains existing mobile-specific behavior while fixing the broader context issue.

#### Testing
- ✅ Keyboard shortcuts work correctly after adding new cards  
- ✅ Link navigation under cursor functions properly  
- ✅ Mobile editing behavior remains unchanged  
- ✅ Editor focus management works as expected  

Fixes the scope/event handling issue that was breaking keyboard navigation throughout the application after card creation.

Fixes #1132