### PR TITLE
fix:Save card on lost focus if not empty

### DIFF
--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -184,6 +184,10 @@ export class KanbanView extends TextFileView implements HoverParent {
   onunload(): void {
     super.onunload();
 
+    // Force save all editing items before view closes
+    const event = new CustomEvent('save-all-editing-items');
+    this.containerEl.dispatchEvent(event);
+
     this.previewQueue.clear();
     this.previewCache.clear();
     this.emitter.emit('queueEmpty');

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
 } from 'preact/hooks';
+import useOnclickOutside from 'react-cool-onclickoutside';
 import { StateManager } from 'src/StateManager';
 import { useNestedEntityPath } from 'src/dnd/components/Droppable';
 import { Path } from 'src/dnd/types';
@@ -205,6 +206,21 @@ export const ItemContent = memo(function ItemContent({
 
   const path = useNestedEntityPath();
   const { onEditDate, onEditTime } = useDatePickers(item);
+
+  const handleClickOutside = useCallback(() => {
+    if (titleRef.current !== null && titleRef.current.trim()) {
+      // Si il y a du contenu modifié, on sauvegarde
+      setEditState(EditingState.complete);
+    } else {
+      // Si pas de modification ou contenu vide, on annule
+      setEditState(EditingState.cancel);
+    }
+  }, [setEditState]);
+
+  const clickOutsideRef = useOnclickOutside(handleClickOutside, {
+    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
+  });
+
   const onEnter = useCallback(
     (cm: EditorView, mod: boolean, shift: boolean) => {
       if (!allowNewLine(stateManager, mod, shift)) {
@@ -256,7 +272,7 @@ export const ItemContent = memo(function ItemContent({
 
   if (!isStatic && isEditing(editState)) {
     return (
-      <div className={c('item-input-wrapper')}>
+      <div className={c('item-input-wrapper')} ref={clickOutsideRef}>
         <MarkdownEditor
           editState={editState}
           className={c('item-input')}

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -209,10 +209,10 @@ export const ItemContent = memo(function ItemContent({
 
   const handleClickOutside = useCallback(() => {
     if (titleRef.current !== null && titleRef.current.trim()) {
-      // Si il y a du contenu modifié, on sauvegarde
+      // If there is modified content, we save
       setEditState(EditingState.complete);
     } else {
-      // Si pas de modification ou contenu vide, on annule
+      // if there is no modification, we cancel
       setEditState(EditingState.cancel);
     }
   }, [setEditState]);

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -235,7 +235,13 @@ export const ItemContent = memo(function ItemContent({
   }, [view, stateManager, boardModifiers, item, path]);
 
   const clickOutsideRef = useOnclickOutside(handleClickOutside, {
-    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
+    ignoreClass: [
+      c('ignore-click-outside'),
+      'mobile-toolbar',
+      'suggestion-container',
+      'menu',
+      'menu-item',
+    ],
   });
 
   const onEnter = useCallback(

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -41,10 +41,10 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
     if (cm) {
       const content = cm.state.doc.toString().trim();
       if (content) {
-        // Si il y a du contenu, on sauvegarde la carte
+        // If there is content, we save the card
         createItem(content);
       } else {
-        // Si il n'y a pas de contenu, on annule
+        // If there is no content, we cancel
         clear();
       }
     } else {

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -20,11 +20,6 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
   const { stateManager } = useContext(KanbanContext);
   const editorRef = useRef<EditorView>();
 
-  const clear = () => setEditState(EditingState.cancel);
-  const clickOutsideRef = useOnclickOutside(clear, {
-    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
-  });
-
   const createItem = (title: string) => {
     addItems([stateManager.getNewItem(title, ' ')]);
     const cm = editorRef.current;
@@ -38,6 +33,28 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
       });
     }
   };
+
+  const clear = () => setEditState(EditingState.cancel);
+
+  const handleClickOutside = () => {
+    const cm = editorRef.current;
+    if (cm) {
+      const content = cm.state.doc.toString().trim();
+      if (content) {
+        // Si il y a du contenu, on sauvegarde la carte
+        createItem(content);
+      } else {
+        // Si il n'y a pas de contenu, on annule
+        clear();
+      }
+    } else {
+      clear();
+    }
+  };
+
+  const clickOutsideRef = useOnclickOutside(handleClickOutside, {
+    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
+  });
 
   if (isEditing(editState)) {
     return (

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -72,7 +72,13 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
   }, [view]);
 
   const clickOutsideRef = useOnclickOutside(handleClickOutside, {
-    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
+    ignoreClass: [
+      c('ignore-click-outside'),
+      'mobile-toolbar',
+      'suggestion-container',
+      'menu',
+      'menu-item',
+    ],
   });
 
   if (isEditing(editState)) {


### PR DESCRIPTION
# Corrections
Correct #1149, #1123, #1091 and #1100 behavior.

New behaviors when click outside a new card:
* if content is empty cancel the card
* if content is not empty validate the card to not lose it

New behavior when click outside a card in edition :
* Validate the edition to not lose the work done in the card if the note change.

This should avoid a lot of frustration 

# Tests 
I tested it on my vault and it works well.