### PR TITLE
Make mobile 'Submit' button work with a single tap

### DIFF
--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -274,7 +274,7 @@ export function MarkdownEditor({
       <div className={classcat(cls)} ref={elRef}></div>
       {Platform.isMobile && (
         <button
-          onClick={() => onSubmit(internalRef.current)}
+          onPointerDown={() => onSubmit(internalRef.current)}
           className={classcat([c('item-submit-button'), 'mod-cta'])}
         >
           {t('Submit')}


### PR DESCRIPTION
| Old Behaviour | New Behaviour |
|---|---|
| Two button presses required if list overlaps keyboard: <br><br> ![ScreenRecording_08-26-2025 12-26-24_1](https://github.com/user-attachments/assets/a1fb7734-ebc6-4f9d-8673-250ef1d16b72) | Single button press, keyboard stays active for next card: <br><br> ![ScreenRecording_08-26-2025 13-02-59_1](https://github.com/user-attachments/assets/703420ad-0780-438a-8d0c-c246cfd20013) |

This works because `onPointerDown` allows the card to submit before the keyboard has a chance to close.