### PR TITLE
Implement dynamic task query lanes feature with manual override and smart movement

### DIFF
--- a/docs/Dynamic-Task-Queries.md
+++ b/docs/Dynamic-Task-Queries.md
@@ -1,0 +1,107 @@
+# Dynamic Task Query Lanes
+
+This feature allows you to create Kanban lanes that are automatically populated with tasks from queries, similar to the Tasks plugin query blocks.
+
+## How to Use
+
+Add a tasks query block in your lane header to make it dynamic:
+
+```markdown
+    ## Today
+    ```tasks
+    not done
+    due today
+    ```
+
+    ## Another Lane
+    ```tasks
+    done
+    due before tomorrow
+    ```
+
+    ## Manual Tasks
+    This lane works normally - you can add tasks manually
+    - [ ] Regular task
+    - [x] Completed task
+```
+
+## Features
+
+### Dynamic Population
+- Lanes with query blocks automatically populate with matching tasks
+- Tasks are pulled from across your vault based on the query criteria
+- Queries use the same syntax as the Tasks plugin
+
+### Manual Override
+- You can still add tasks manually to any lane, including query lanes
+- Manual tasks appear alongside query results
+- Manual tasks are preserved when the board is saved
+
+### Smart Movement
+- When you move a task to a query lane, its properties are automatically updated to match the query
+- Moving a task to a "due today" lane will add today's date
+- Moving to a "done" lane will mark the task as completed
+- Moving to a "not done" lane will mark the task as incomplete
+
+### Query Examples
+
+#### Due Date Queries
+```markdown
+    ```tasks
+    not done
+    due today
+    ```
+
+    ```tasks
+    not done
+    due this week
+    ```
+```
+
+#### Status Queries  
+```markdown
+    ```tasks
+    done
+    ```
+
+    ```tasks
+    not done
+    ```
+```
+
+#### Priority Queries
+```markdown
+    ```tasks
+    not done
+    priority high
+    ```
+```
+
+#### Combined Queries
+```markdown
+    ```tasks
+    not done
+    due today
+    priority high
+    ```
+```
+
+## Technical Details
+
+### Lane Data Structure
+- Lanes now support a `query` field in their data
+- Query results are marked with `fromQuery: true` to distinguish from manual tasks
+- Only manual tasks are serialized back to markdown to avoid duplication
+
+### Refresh Behavior
+- Dynamic lanes refresh when file metadata changes
+- Manual refresh can be triggered by calling `refreshDynamicLanes()`
+- Query results update automatically when underlying tasks change
+
+### Compatibility
+- Requires the Tasks plugin to be installed and enabled
+- Falls back gracefully if Tasks plugin is not available
+- Existing boards continue to work unchanged
+
+> [!WARNING]
+> Is scheduled at Tasks plugin roadmap a [future feature to configure the datetime format](https://github.com/obsidian-tasks-group/obsidian-tasks/issues/3372). This may affect how due dates are interpreted in queries. There's a pin at `src/parsers/helpers/taskQuery.ts:119` and I'll address to it in the future commits.

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -8,6 +8,7 @@ import { getDefaultDateFormat, getDefaultTimeFormat } from './components/helpers
 import { Board, BoardTemplate, Item } from './components/types';
 import { ListFormat } from './parsers/List';
 import { BaseFormat, frontmatterKey, shouldRefreshBoard } from './parsers/common';
+import { refreshDynamicLanes } from './parsers/helpers/taskQuery';
 import { getTaskStatusDone } from './parsers/helpers/inlineMetadata';
 import { defaultDateTrigger, defaultMetadataPosition, defaultTimeTrigger } from './settingHelpers';
 
@@ -351,6 +352,18 @@ export class StateManager {
 
   onFileMetadataChange() {
     this.reparseBoardFromMd();
+    this.refreshDynamicLanes();
+  }
+
+  refreshDynamicLanes() {
+    const board = this.state;
+    const refreshedLanes = refreshDynamicLanes(this, board.children);
+    
+    if (refreshedLanes !== board.children) {
+      this.setState(update(board, {
+        children: { $set: refreshedLanes }
+      }), false);
+    }
   }
 
   async reparseBoardFromMd() {

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -11,6 +11,7 @@ import {
   getTaskStatusPreDone,
   toggleTask,
 } from 'src/parsers/helpers/inlineMetadata';
+import { updateItemForQuery } from 'src/parsers/helpers/taskQuery';
 
 import { SearchContextProps } from './context';
 import { Board, DataKey, DateColor, Item, Lane, PageData, TagColor } from './types';
@@ -42,11 +43,16 @@ export function maybeCompleteForMove(
   destinationPath: Path,
   item: Item
 ): { next: Item; replacement?: Item } {
-  const sourceParent = getEntityFromPath(sourceBoard, sourcePath.slice(0, -1));
-  const destinationParent = getEntityFromPath(destinationBoard, destinationPath.slice(0, -1));
+  const sourceParent = getEntityFromPath(sourceBoard, sourcePath.slice(0, -1)) as Lane;
+  const destinationParent = getEntityFromPath(destinationBoard, destinationPath.slice(0, -1)) as Lane;
 
   const oldShouldComplete = sourceParent?.data?.shouldMarkItemsComplete;
   const newShouldComplete = destinationParent?.data?.shouldMarkItemsComplete;
+
+  // Check if moving to a query lane and update item for query if needed
+  if (destinationParent?.data?.query) {
+    item = updateItemForQuery(item, destinationParent.data.query);
+  }
 
   // If neither the old or new lane set it complete, leave it alone
   if (!oldShouldComplete && !newShouldComplete) return { next: item };

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -17,6 +17,7 @@ export interface LaneData {
   shouldMarkItemsComplete?: boolean;
   title: string;
   maxItems?: number;
+  query?: string;
   dom?: HTMLDivElement;
   forceEditMode?: boolean;
   sorted?: LaneSort | string;
@@ -87,6 +88,12 @@ export interface ItemData {
   titleSearchRaw: string;
   metadata: ItemMetadata;
   forceEditMode?: boolean;
+  fromQuery?: boolean;
+  querySource?: {
+    path: string;
+    line: number;
+    blockId?: string;
+  };
 }
 
 export interface ErrorReport {

--- a/src/parsers/formats/list.ts
+++ b/src/parsers/formats/list.ts
@@ -407,7 +407,14 @@ function itemToMd(item: Item) {
 function laneToMd(lane: Lane) {
   const lines: string[] = [];
 
-  lines.push(`## ${replaceNewLines(laneTitleWithMaxItems(lane.data.title, lane.data.maxItems))}`);
+  let title = replaceNewLines(laneTitleWithMaxItems(lane.data.title, lane.data.maxItems));
+  
+  // Add query block if lane has a query
+  if (lane.data.query) {
+    title += `\n\`\`\`tasks\n${lane.data.query}\n\`\`\``;
+  }
+
+  lines.push(`## ${title}`);
 
   lines.push('');
 
@@ -415,7 +422,12 @@ function laneToMd(lane: Lane) {
     lines.push(completeString);
   }
 
-  lane.children.forEach((item) => {
+  // Only serialize non-query items to avoid duplicating query results
+  const itemsToSerialize = lane.children.filter((item: Item) => 
+    !(item.data as any)?.fromQuery
+  );
+
+  itemsToSerialize.forEach((item) => {
     lines.push(itemToMd(item));
   });
 

--- a/src/parsers/helpers/hydrateBoard.ts
+++ b/src/parsers/helpers/hydrateBoard.ts
@@ -7,8 +7,15 @@ import { getEntityFromPath } from 'src/dnd/util/data';
 import { Op } from 'src/helpers/patch';
 
 import { getSearchValue } from '../common';
+import { populateLaneFromQuery } from './taskQuery';
 
 export function hydrateLane(stateManager: StateManager, lane: Lane) {
+  // If the lane has a query, populate it with tasks from the query
+  if (lane.data.query) {
+    const populatedItems = populateLaneFromQuery(stateManager, lane);
+    lane.children = populatedItems;
+  }
+  
   return lane;
 }
 

--- a/src/parsers/helpers/parser.ts
+++ b/src/parsers/helpers/parser.ts
@@ -60,8 +60,20 @@ export function dedentNewLines(str: string) {
 export function parseLaneTitle(str: string) {
   str = replaceBrs(str);
 
-  const match = str.match(/^(.*?)\s*\((\d+)\)$/);
-  if (match == null) return { title: str, maxItems: 0 };
+  // Check for tasks query block first
+  const queryMatch = str.match(/```tasks\n([\s\S]*?)\n```/);
+  let query: string | undefined;
+  
+  if (queryMatch) {
+    query = queryMatch[1].trim();
+    // Remove the query block from the title
+    str = str.replace(/```tasks\n[\s\S]*?\n```/, '').trim();
+  }
 
-  return { title: match[1], maxItems: Number(match[2]) };
+  const match = str.match(/^(.*?)\s*\((\d+)\)$/);
+  if (match == null) {
+    return { title: str, maxItems: 0, query };
+  }
+
+  return { title: match[1], maxItems: Number(match[2]), query };
 }

--- a/src/parsers/helpers/taskQuery.ts
+++ b/src/parsers/helpers/taskQuery.ts
@@ -1,0 +1,222 @@
+import { TFile } from 'obsidian';
+import { StateManager } from '../../StateManager';
+import { Item, Lane } from '../../components/types';
+import { generateInstanceId } from '../../components/helpers';
+import { getTasksPlugin } from './inlineMetadata';
+
+export interface TaskQueryResult {
+  description: string;
+  status: string;
+  path: string;
+  line: number;
+  blockId?: string;
+  priority?: string;
+  tags?: string[];
+  due?: Date;
+  done?: Date;
+  created?: Date;
+  start?: Date;
+  scheduled?: Date;
+}
+
+/**
+ * Populates a lane with tasks from a query, merging with existing manually added items
+ */
+export function populateLaneFromQuery(
+  stateManager: StateManager,
+  lane: Lane
+): Item[] {
+  if (!lane.data.query) {
+    return lane.children;
+  }
+
+  const tasksPlugin = getTasksPlugin();
+  if (!tasksPlugin) {
+    console.warn('Tasks plugin not available for query execution');
+    return lane.children;
+  }
+
+  try {
+    // Get the Tasks plugin's query engine
+    const queryEngine = tasksPlugin.apiV1?.queryTasks;
+    if (!queryEngine) {
+      console.warn('Tasks plugin query API not available');
+      return lane.children;
+    }
+
+    // Execute the tasks query
+    const queryResults = queryEngine(lane.data.query, stateManager.file.path);
+
+    if (!queryResults || !Array.isArray(queryResults)) {
+      return lane.children;
+    }
+
+    // Convert query results to Kanban items
+    const queryItems: Item[] = queryResults.map((task: TaskQueryResult) => {
+      const content = task.description || '';
+      const checkChar = task.status || ' ';
+      
+      // Create a new item with the task data
+      const item = stateManager.getNewItem(content, checkChar);
+      
+      // Mark this item as being from a query so we can distinguish it
+      item.data = {
+        ...item.data,
+        fromQuery: true,
+        querySource: {
+          path: task.path,
+          line: task.line,
+          blockId: task.blockId,
+        }
+      };
+
+      // Add metadata from the task
+      if (task.due) {
+        item.data.metadata.dateStr = task.due.toISOString().split('T')[0];
+      }
+      
+      if (task.tags) {
+        item.data.metadata.tags = task.tags;
+      }
+
+      if (task.priority) {
+        // Add priority to the task content if not already present
+        if (!content.includes('🔺') && !content.includes('⏫') && !content.includes('🔼')) {
+          const prioritySymbol = getPrioritySymbol(task.priority);
+          if (prioritySymbol) {
+            item.data.title = `${content} ${prioritySymbol}`;
+            item.data.titleRaw = `${content} ${prioritySymbol}`;
+          }
+        }
+      }
+
+      return item;
+    });
+
+    // Filter out manually added items that aren't from queries
+    const manualItems = lane.children.filter((item: Item) => 
+      !(item.data as any)?.fromQuery
+    );
+
+    // Merge query items with manual items
+    return [...queryItems, ...manualItems];
+  } catch (error) {
+    console.error('Error executing tasks query:', error);
+    return lane.children;
+  }
+}
+
+/**
+ * Updates an item's properties to match the target lane's query criteria.
+ * This is a simplified implementation - a real implementation would need
+ * more sophisticated query parsing to understand what properties to set,
+ * this is here to define a starting point.
+ */
+export function updateItemForQuery(item: Item, query: string): Item {
+  // Parse common query patterns and update item accordingly
+  if (query.includes('due today')) {
+    // Add due date to task if not present
+    // TODO: Get the configurated date format from Tasks definitions
+    const today = new Date().toISOString().split('T')[0]; // teporary
+
+    if (!item.data.titleRaw.includes('📅')) {
+      const updatedContent = `${item.data.titleRaw} 📅 ${today}`;
+      return {
+        ...item,
+        data: {
+          ...item.data,
+          title: updatedContent,
+          titleRaw: updatedContent,
+          metadata: {
+            ...item.data.metadata,
+            dateStr: today
+          }
+        }
+      };
+    }
+  }
+  
+  if (query.includes('done') && !query.includes('not done')) {
+    // Mark item as completed
+    return {
+      ...item,
+      data: {
+        ...item.data,
+        checked: true,
+        checkChar: 'x'
+      }
+    };
+  }
+  
+  if (query.includes('not done')) {
+    // Mark item as not completed
+    return {
+      ...item,
+      data: {
+        ...item.data,
+        checked: false,
+        checkChar: ' '
+      }
+    };
+  }
+
+  if (query.includes('priority high')) {
+    // Add high priority if not present
+    if (!item.data.titleRaw.includes('🔺')) {
+      const updatedContent = `${item.data.titleRaw} 🔺`;
+      return {
+        ...item,
+        data: {
+          ...item.data,
+          title: updatedContent,
+          titleRaw: updatedContent
+        }
+      };
+    }
+  }
+
+  return item;
+}
+
+/**
+ * Gets the appropriate priority symbol for a priority level ⏬🔽🔼⏫🔺
+ */
+function getPrioritySymbol(priority: string): string {
+  switch (priority?.toLowerCase()) {
+    case 'highest':
+      return '🔺';
+    case 'high':
+      return '⏫';
+    case 'medium':
+      return '🔼';
+    case 'low':
+      return '🔽';
+    case 'lowest':
+      return '⏬';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Checks if a lane has dynamic content from queries
+ */
+export function isLaneDynamic(lane: Lane): boolean {
+  return !!lane.data.query;
+}
+
+/**
+ * Refreshes all dynamic lanes in a board
+ */
+export function refreshDynamicLanes(stateManager: StateManager, lanes: Lane[]): Lane[] {
+  return lanes.map(lane => {
+    if (isLaneDynamic(lane)) {
+      const updatedChildren = populateLaneFromQuery(stateManager, lane);
+      return {
+        ...lane,
+        children: updatedChildren
+      };
+    }
+    return lane;
+  });
+}


### PR DESCRIPTION
## Info
This pull request introduces a major new feature: **Dynamic Task Query Lanes**, allowing Kanban lanes to be automatically populated with tasks matching a query, similar to the Tasks plugin's query blocks. This enables powerful, dynamic boards that update as your tasks change, while still supporting manual tasks and movement between lanes. The implementation includes new data structures, helpers, and serialization logic, along with comprehensive documentation.

## The most important changes are:

### **Dynamic Query Lane Feature:**
- Added support for dynamic lanes that are populated by Tasks plugin queries. Lanes can now include a query block in their header, which will automatically pull in matching tasks from across the vault. Manual tasks can still be added and are preserved alongside query results. [[1]](diffhunk://#diff-fb09f757ee760e09f52577b1c2b95a4baed1270a0d045653680b1869e8dd535aR1-R107) [[2]](diffhunk://#diff-9b909becd3cda72d27670f588ebcdb1ffd0aac1f515343b0ca4e64071b9045c4R20) [[3]](diffhunk://#diff-9b909becd3cda72d27670f588ebcdb1ffd0aac1f515343b0ca4e64071b9045c4R91-R96) [[4]](diffhunk://#diff-6aa19777db3bddc9106f9b61f41233737d112252f9802b3623edc3edb81cfa4fR63-R78) [[5]](diffhunk://#diff-e7b1a7135304416d987be2ffc7219c842cf7d16abc9454f0eb106c891468e8f3L410-R430) [[6]](diffhunk://#diff-df6c07508fa3273124bfbfbb8f52513cd7fb52f0ce3838010bca2c749c194a72R10-R18) [[7]](diffhunk://#diff-026fb21a3c89b19258538ec293fb0bd04a29c593b8dd5be44a003de940cd9ecdR1-R222)

### **State Management and Refresh Logic:**
- Introduced `refreshDynamicLanes` to update dynamic lanes whenever file metadata changes or on demand, ensuring query results stay current as underlying tasks change. [[1]](diffhunk://#diff-39b918a446889fae6708112b70c6ab5b7bcbc0bff7bf99d97177aaf72180e3f2R11) [[2]](diffhunk://#diff-39b918a446889fae6708112b70c6ab5b7bcbc0bff7bf99d97177aaf72180e3f2R355-R366) [[3]](diffhunk://#diff-026fb21a3c89b19258538ec293fb0bd04a29c593b8dd5be44a003de940cd9ecdR1-R222)

### **Task Movement and Smart Updating:**
- Enhanced task movement logic so that when a task is moved into a query lane, its properties (such as completion status, due date, or priority) are automatically updated to match the lane's query criteria. [[1]](diffhunk://#diff-2930d530fd8acfec6b2a908ed8a277068c35e6dfa0e37ddf7614eb6a4a99bfd2R14) [[2]](diffhunk://#diff-2930d530fd8acfec6b2a908ed8a277068c35e6dfa0e37ddf7614eb6a4a99bfd2L45-R56) [[3]](diffhunk://#diff-026fb21a3c89b19258538ec293fb0bd04a29c593b8dd5be44a003de940cd9ecdR1-R222)

### **Serialization and Parsing:**
- Updated lane serialization and parsing to support query blocks in lane headers, ensuring only manual tasks are written back to markdown to avoid duplication of query results. [[1]](diffhunk://#diff-e7b1a7135304416d987be2ffc7219c842cf7d16abc9454f0eb106c891468e8f3L410-R430) [[2]](diffhunk://#diff-6aa19777db3bddc9106f9b61f41233737d112252f9802b3623edc3edb81cfa4fR63-R78)

### **Documentation:**
- Added a comprehensive `Dynamic-Task-Queries.md` guide explaining usage, features, technical details, and compatibility notes for dynamic query lanes.

> [!NOTE]
> I've noticed that there's no test coverage, I've been also creating some test cases (with Jest) but don't know what are your intended policy, I'll add in a additonal comment the informations.