### PR TITLE
Add inline board notes feature

### DIFF
--- a/src/components/BoardNotes/BoardNotes.tsx
+++ b/src/components/BoardNotes/BoardNotes.tsx
@@ -1,0 +1,148 @@
+import { EditorView } from '@codemirror/view';
+import classcat from 'classcat';
+import { useCallback, useContext, useEffect, useRef, useState } from 'preact/compat';
+import { t } from 'src/lang/helpers';
+
+import { MarkdownEditor } from '../Editor/MarkdownEditor';
+import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
+import { KanbanContext } from '../context';
+import { c } from '../helpers';
+import { EditCoordinates, EditState, EditingState, isEditing } from '../types';
+import { Icon } from '../Icon/Icon';
+
+interface BoardNotesProps {
+  notes: string | undefined;
+}
+
+export function BoardNotes({ notes }: BoardNotesProps) {
+  const { stateManager, boardModifiers } = useContext(KanbanContext);
+  const [editState, setEditState] = useState<EditState>(null);
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+  const notesRef = useRef<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Handle save when edit completes
+  useEffect(() => {
+    if (editState === EditingState.complete) {
+      if (notesRef.current !== null) {
+        boardModifiers.updateBoardNotes(notesRef.current);
+      }
+      notesRef.current = null;
+      setEditState(null);
+    } else if (editState === EditingState.cancel) {
+      notesRef.current = null;
+      setEditState(null);
+    }
+  }, [editState, boardModifiers]);
+
+  const onEnter = useCallback(
+    (cm: EditorView, mod: boolean, shift: boolean) => {
+      // Always allow new lines in board notes since it's a multi-line editor
+      return false;
+    },
+    []
+  );
+
+  const onSubmit = useCallback(() => setEditState(EditingState.complete), []);
+
+  const onEscape = useCallback(() => {
+    setEditState(EditingState.cancel);
+    return true;
+  }, []);
+
+  const onDoubleClick = useCallback((e: MouseEvent) => {
+    setEditState({ x: e.clientX, y: e.clientY } as EditCoordinates);
+  }, []);
+
+  const toggleCollapse = useCallback(() => {
+    setIsCollapsed((prev) => !prev);
+  }, []);
+
+  const onAddNotes = useCallback(() => {
+    boardModifiers.updateBoardNotes('');
+    setEditState({ x: 0, y: 0 } as EditCoordinates);
+  }, [boardModifiers]);
+
+  // If no notes and not editing, show add button
+  if (!notes && !isEditing(editState)) {
+    return (
+      <div className={c('board-notes-empty')}>
+        <button
+          className={c('board-notes-add-button')}
+          onClick={onAddNotes}
+          aria-label={t('Add board notes')}
+        >
+          <Icon name="lucide-plus" />
+          <span>{t('Add board notes')}</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={classcat([
+        c('board-notes'),
+        {
+          [c('board-notes-collapsed')]: isCollapsed,
+          [c('board-notes-editing')]: isEditing(editState),
+        },
+      ])}
+    >
+      <div className={c('board-notes-header')}>
+        <button
+          className={c('board-notes-collapse-button')}
+          onClick={toggleCollapse}
+          aria-label={isCollapsed ? t('Expand notes') : t('Collapse notes')}
+        >
+          <Icon name={isCollapsed ? 'lucide-chevron-right' : 'lucide-chevron-down'} />
+        </button>
+        <span className={c('board-notes-title')}>{t('Notes')}</span>
+      </div>
+      {!isCollapsed && (
+        <div className={c('board-notes-content')}>
+          {isEditing(editState) ? (
+            <div className={c('board-notes-input-wrapper')}>
+              <MarkdownEditor
+                editState={editState}
+                className={c('board-notes-input')}
+                onEnter={onEnter}
+                onEscape={onEscape}
+                onSubmit={onSubmit}
+                value={notes || ''}
+                placeholder={t('Enter board notes...')}
+                onChange={(update) => {
+                  if (update.docChanged) {
+                    notesRef.current = update.state.doc.toString();
+                  }
+                }}
+              />
+              <div className={c('board-notes-actions')}>
+                <button
+                  className={classcat([c('board-notes-save-button'), 'mod-cta'])}
+                  onClick={() => setEditState(EditingState.complete)}
+                >
+                  {t('Save')}
+                </button>
+                <button
+                  className={c('board-notes-cancel-button')}
+                  onClick={() => setEditState(EditingState.cancel)}
+                >
+                  {t('Cancel')}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className={c('board-notes-preview')} onDblClick={onDoubleClick}>
+              <MarkdownRenderer
+                className={c('board-notes-markdown')}
+                markdownString={notes || ''}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -14,6 +14,7 @@ import { t } from 'src/lang/helpers';
 import { DndScope } from '../dnd/components/Scope';
 import { getBoardModifiers } from '../helpers/boardModifiers';
 import { frontmatterKey } from '../parsers/common';
+import { BoardNotes } from './BoardNotes/BoardNotes';
 import { Icon } from './Icon/Icon';
 import { Lanes } from './Lane/Lane';
 import { LaneForm } from './Lane/LaneForm';
@@ -261,6 +262,7 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
                 </a>
               </div>
             )}
+            <BoardNotes notes={boardData.data.boardNotes} />
             {boardView === 'table' ? (
               <TableView boardData={boardData} stateManager={stateManager} />
             ) : (

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -100,6 +100,7 @@ export interface BoardData {
   frontmatter: Record<string, number | string | Array<number | string>>;
   archive: Item[];
   errors: ErrorReport[];
+  boardNotes?: string;
 }
 
 export type Item = Nestable<ItemData>;

--- a/src/helpers/boardModifiers.ts
+++ b/src/helpers/boardModifiers.ts
@@ -34,6 +34,7 @@ export interface BoardModifiers {
   updateItem: (path: Path, item: Item) => void;
   archiveItem: (path: Path) => void;
   duplicateEntity: (path: Path) => void;
+  updateBoardNotes: (notes: string | undefined) => void;
 }
 
 export function getBoardModifiers(view: KanbanView, stateManager: StateManager): BoardModifiers {
@@ -274,6 +275,18 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
         }
 
         return insertEntity(boardData, path, [entityWithNewID]);
+      });
+    },
+
+    updateBoardNotes: (notes: string | undefined) => {
+      stateManager.setState((boardData) => {
+        return update(boardData, {
+          data: {
+            boardNotes: {
+              $set: notes?.trim() || undefined,
+            },
+          },
+        });
       });
     },
   };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -274,6 +274,13 @@ const en = {
 
   // components/Editor/MarkdownEditor.tsx
   Submit: 'Submit',
+
+  // components/BoardNotes/BoardNotes.tsx
+  Notes: 'Notes',
+  'Add board notes': 'Add board notes',
+  'Expand notes': 'Expand notes',
+  'Collapse notes': 'Collapse notes',
+  'Enter board notes...': 'Enter board notes...',
 };
 
 export type Lang = typeof en;

--- a/src/styles.less
+++ b/src/styles.less
@@ -1782,3 +1782,165 @@ body:not(.native-scrollbars) .kanban-plugin__scroll-container::-webkit-scrollbar
     background-color: var(--date-background-color, rgba(var(--mono-rgb-100), 0.05));
   }
 }
+
+// Board Notes Styles
+.kanban-plugin__board-notes-empty {
+  padding-block: 8px;
+  padding-inline: 12px;
+}
+
+.kanban-plugin__board-notes-add-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-block: 6px;
+  padding-inline: 10px;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+  transition: all 150ms ease;
+
+  &:hover {
+    color: var(--text-normal);
+    border-color: var(--text-muted);
+    background: var(--background-secondary);
+  }
+
+  .kanban-plugin__icon {
+    display: flex;
+  }
+}
+
+.kanban-plugin__board-notes {
+  margin-block: 0 10px;
+  margin-inline: 12px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  overflow: hidden;
+}
+
+.kanban-plugin__board-notes-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-block: 6px;
+  padding-inline: 8px;
+  background: var(--background-secondary-alt);
+  border-bottom: 1px solid var(--background-modifier-border);
+  user-select: none;
+}
+
+.kanban-plugin__board-notes-collapsed .kanban-plugin__board-notes-header {
+  border-bottom: none;
+}
+
+.kanban-plugin__board-notes-collapse-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-s);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+  }
+
+  .kanban-plugin__icon {
+    display: flex;
+  }
+}
+
+.kanban-plugin__board-notes-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.kanban-plugin__board-notes-content {
+  padding: 10px;
+}
+
+.kanban-plugin__board-notes-preview {
+  cursor: text;
+  min-height: 1.5em;
+
+  &:hover {
+    background: var(--background-primary-alt);
+    border-radius: var(--radius-s);
+  }
+
+  .kanban-plugin__markdown-preview-wrapper {
+    --font-text-size: 0.875rem;
+    --line-height-normal: var(--line-height-tight);
+  }
+}
+
+.kanban-plugin__board-notes-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kanban-plugin__board-notes-input {
+  --font-text-size: 0.875rem;
+
+  min-height: 60px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 8px;
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+
+  &:focus-within {
+    border-color: var(--background-modifier-border-focus);
+    outline: 1px solid var(--background-modifier-border-focus);
+  }
+}
+
+.kanban-plugin__board-notes-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.kanban-plugin__board-notes-save-button,
+.kanban-plugin__board-notes-cancel-button {
+  padding-block: 4px;
+  padding-inline: 10px;
+  font-size: 0.75rem;
+  border-radius: var(--radius-s);
+  cursor: pointer;
+}
+
+.kanban-plugin__board-notes-save-button {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border: none;
+
+  &:hover {
+    background: var(--interactive-accent-hover);
+  }
+}
+
+.kanban-plugin__board-notes-cancel-button {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--background-modifier-border);
+
+  &:hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+  }
+}


### PR DESCRIPTION
This feature allows users to add notes at the top of a Kanban board that appear before the columns. The notes are:
- Parsed from content before the first ## heading
- Rendered in a collapsible section above the board
- Editable inline with full markdown support
- Persisted back to the markdown file

Changes:
- Add boardNotes field to BoardData interface
- Modify parser to extract pre-heading content as board notes
- Modify serializer to write notes back to markdown
- Create BoardNotes component with collapse/expand functionality
- Add updateBoardNotes board modifier
- Add CSS styles for the notes section
- Add translation strings for the new feature