### PR TITLE
fix: Reduce drag scroll speed to prevent overshooting columns (#1110)

### DIFF
--- a/src/dnd/managers/ScrollManager.ts
+++ b/src/dnd/managers/ScrollManager.ts
@@ -23,7 +23,7 @@ export type IntersectionObserverHandler = (entry: IntersectionObserverEntry) => 
 
 export const scrollContainerEntityType = 'scroll-container';
 
-const scrollStrengthModifier = 8;
+const scrollStrengthModifier = 2.5;
 
 const sides: Side[] = ['top', 'right', 'bottom', 'left'];
 


### PR DESCRIPTION
## Problem

When dragging cards across a Kanban board with many columns, the horizontal scroll speed is far too fast, making it nearly impossible to drop cards into adjacent columns. The board scrolls all the way to the end instead of allowing precise placement.

This affects both desktop and mobile users, as reported in #1110 and confirmed by multiple users in #1166.

## Root Cause

The `scrollStrengthModifier` constant in `ScrollManager.ts` was set to `8`. At 60fps, this produces scroll speeds up to **480px/sec** when the cursor is near the edge of the scroll zone — far too fast for accurate card placement.

## Fix

Reduced `scrollStrengthModifier` from `8` to `2.5`.

| | Old (8) | New (2.5) |
|---|---|---|
| Max speed (at edge) | ~480 px/sec | ~150 px/sec |
| Mid-zone speed | ~240 px/sec | ~75 px/sec |
| Min speed (deep zone) | ~0 px/sec | ~0 px/sec |

The new value of `2.5` provides a good balance:
- **Fast enough** to traverse large boards without excessive dragging
- **Slow enough** to accurately drop cards one or two columns over
- Consistent with the user testing in #1110 where `scrollStrengthModifier=1` was confirmed as usable (we use a slightly higher value for better large-board ergonomics)

## Testing

- Tested with 7+ column boards
- Drag from first column to adjacent columns is now controllable
- Drag across the entire board still completes in a reasonable time

Fixes #1110