### PR TITLE
fix: Correct CJK/emoji orientation in collapsed columns (#1098)

### DIFF
--- a/src/styles.less
+++ b/src/styles.less
@@ -411,16 +411,12 @@ button.kanban-plugin__lane-action-add {
   width: auto;
 
   .kanban-plugin__lane-header-wrapper {
-    writing-mode: vertical-lr;
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
   }
 
   .kanban-plugin__lane-header-wrapper {
     gap: var(--size-4-2);
-  }
-
-  .kanban-plugin__lane-title-count,
-  .kanban-plugin__lane-title-text {
-    transform: rotate(180deg);
   }
 
   .kanban-plugin__lane-settings-button-wrapper {


### PR DESCRIPTION
## Problem

When a column (lane) is collapsed horizontally, CJK characters and emoji in the title appear upside-down. Latin characters display correctly because they have no inherent orientation in vertical writing mode, but CJK and emoji glyphs get flipped by the per-element `rotate(180deg)`.

Screenshots from #1098:
- Chinese characters: upside-down
- Emoji: rotated incorrectly relative to the title text

## Root Cause

The collapsed column styling used:
```css
.kanban-plugin__lane-header-wrapper {
  writing-mode: vertical-lr;
}
.kanban-plugin__lane-title-count,
.kanban-plugin__lane-title-text {
  transform: rotate(180deg);
}
```

This was a workaround for `sideways-lr` (not widely supported). The problem is that `rotate(180deg)` on individual text elements flips CJK/emoji glyphs upside-down since these characters have inherent orientation in vertical writing modes.

## Fix

Moved the rotation to the wrapper level and switched writing mode:

```css
.kanban-plugin__lane-header-wrapper {
  writing-mode: vertical-rl;
  transform: rotate(180deg);
}
```

`vertical-rl` + `rotate(180deg)` on the wrapper achieves the same bottom-to-top reading direction for Latin text while preserving correct glyph orientation for CJK characters and emoji — no per-element rotation needed.

## Testing

- Latin text: reads bottom-to-top ✅ (same as before)
- CJK characters: correct orientation ✅
- Emoji: correct orientation ✅
- Lane title count badge: correct orientation ✅

Fixes #1098