### PR TITLE
Fix: stop silently failing when failing to create new notes. fixes #1028

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -1,5 +1,5 @@
 import update from 'immutability-helper';
-import { Menu, Platform, TFile, TFolder } from 'obsidian';
+import { Menu, Notice, Platform, TFile, TFolder } from 'obsidian';
 import { Dispatch, StateUpdater, useCallback } from 'preact/hooks';
 import { StateManager } from 'src/StateManager';
 import { Path } from 'src/dnd/types';
@@ -72,10 +72,21 @@ export function useItemMenu({
                 ? (stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string) as TFolder)
                 : stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
 
-              const newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
-                targetFolder,
-                sanitizedTitle
-              )) as TFile;
+              let newFile: TFile;
+
+              try {
+                newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
+                  targetFolder,
+                  sanitizedTitle
+                )) as TFile;
+              } catch (e) {
+                new Notice(
+                  t('The note could not be created. Try reducing the length of the text before creating a note.'),
+                  5000,
+                );
+
+                return;
+              }
 
               const newLeaf = stateManager.app.workspace.splitActiveLeaf();
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -236,6 +236,8 @@ const en = {
   'Move to top': 'Move to top',
   'Move to bottom': 'Move to bottom',
   'Move to list': 'Move to list',
+  'The note could not be created. Try reducing the length of the text before creating a note.':
+    'The note could not be created. Try reducing the length of the text before creating a note.',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Enter list title...',


### PR DESCRIPTION
This pull request fixes #1028 by adding error handling around the creation of the new note. If an error occurs, it now no longer fails silently, and will display a message in Obsidian advising to try reducing the text length before creating a note (see screenshot below).

<img width="843" height="311" alt="image" src="https://github.com/user-attachments/assets/ad852aaf-c3bf-41a2-8935-3ce8aaff39af" />

I noticed someone else has added a commit in another fork using Claude to try and address this, but that commit is invalid - it is doing an arbitrary check on the file name length, which won't work cross platform and won't work for ecryptfs file systems. The right way to do this is as has been done in this pull request (i.e. catching the file system error)