### PR TITLE
Add "Move to Column" command

### DIFF
--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -73,9 +73,9 @@ const ItemInner = memo(function ItemInner({
   const showItemMenu = useItemMenu({
     boardModifiers,
     item,
+    path,
     setEditState: setEditState,
     stateManager,
-    path,
   });
 
   const onContextMenu: JSX.MouseEventHandler<HTMLDivElement> = useCallback(

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -15,6 +15,7 @@ import {
   constructMenuTimePickerOnChange,
   constructTimePicker,
 } from './helpers';
+import { MoveToColumnModal } from './MoveToColumnModal';
 
 const illegalCharsRegEx = /[\\/:"*?<>|]+/g;
 const embedRegEx = /!?\[\[([^\]]*)\.[^\]]+\]\]/g;
@@ -176,6 +177,16 @@ export function useItemMenu({
             .onClick(() => boardModifiers.moveItemToBottom(path));
         })
         .addItem((i) => {
+          const hasOtherColumns = stateManager.state.children.length > 1;
+          i.setIcon('lucide-square-kanban')
+            .setTitle(t('Move to column'))
+            .setDisabled(!hasOtherColumns)
+            .onClick(() => {
+              if (!hasOtherColumns) return;
+              new MoveToColumnModal(stateManager.app, stateManager, path).open();
+            });
+        })
+        .addItem((i) => {
           i.setIcon('lucide-archive')
             .setTitle(t('Archive card'))
             .onClick(() => boardModifiers.archiveItem(path));
@@ -265,36 +276,24 @@ export function useItemMenu({
 
       menu.addSeparator();
 
-      const addMoveToOptions = (menu: Menu) => {
-        const lanes = stateManager.state.children;
-        if (lanes.length <= 1) return;
-        for (let i = 0, len = lanes.length; i < len; i++) {
-          menu.addItem((item) =>
-            item
-              .setIcon('lucide-square-kanban')
-              .setChecked(path[0] === i)
-              .setTitle(lanes[i].data.title)
-              .onClick(() => {
-                if (path[0] === i) return;
-                stateManager.setState((boardData) => {
-                  return moveEntity(boardData, path, [i, 0]);
-                });
-              })
-          );
-        }
-      };
-
       if (Platform.isPhone) {
-        addMoveToOptions(menu);
-      } else {
-        menu.addItem((item) => {
-          const submenu = (item as any)
-            .setTitle(t('Move to list'))
-            .setIcon('lucide-square-kanban')
-            .setSubmenu();
-
-          addMoveToOptions(submenu);
-        });
+        const lanes = stateManager.state.children;
+        if (lanes.length > 1) {
+          for (let i = 0, len = lanes.length; i < len; i++) {
+            menu.addItem((item) =>
+              item
+                .setIcon('lucide-square-kanban')
+                .setChecked(path[0] === i)
+                .setTitle(lanes[i].data.title)
+                .onClick(() => {
+                  if (path[0] === i) return;
+                  stateManager.setState((boardData) => {
+                    return moveEntity(boardData, path, [i, 0]);
+                  });
+                })
+            );
+          }
+        }
       }
 
       menu.showAtPosition(coordinates);

--- a/src/components/Item/MoveToColumnModal.ts
+++ b/src/components/Item/MoveToColumnModal.ts
@@ -1,0 +1,49 @@
+import { App, SuggestModal } from 'obsidian';
+import { StateManager } from 'src/StateManager';
+import { Path } from 'src/dnd/types';
+import { moveEntity } from 'src/dnd/util/data';
+import { t } from 'src/lang/helpers';
+
+interface ColumnSuggestion {
+  title: string;
+  index: number;
+}
+
+export class MoveToColumnModal extends SuggestModal<ColumnSuggestion> {
+  private readonly currentPath: Path;
+  private readonly stateManager: StateManager;
+
+  constructor(app: App, stateManager: StateManager, path: Path) {
+    super(app);
+    this.currentPath = path;
+    this.stateManager = stateManager;
+    this.setPlaceholder(t('Move to column'));
+    this.emptyStateText = t('No other columns available');
+  }
+
+  getSuggestions(query: string): ColumnSuggestion[] {
+    const normalizedQuery = query.trim().toLowerCase();
+    return this.stateManager.state.children
+      .map((lane, index) => ({
+        index,
+        title: lane.data.title,
+      }))
+      .filter(
+        ({ index, title }) =>
+          index !== this.currentPath[0] &&
+          (!normalizedQuery || title.toLowerCase().includes(normalizedQuery))
+      );
+  }
+
+  renderSuggestion(value: ColumnSuggestion, el: HTMLElement) {
+    el.setText(value.title);
+  }
+
+  onChooseSuggestion(value: ColumnSuggestion): void {
+    this.stateManager.setState((boardData) => {
+      const targetLane = boardData.children[value.index];
+      const destinationPath: Path = [value.index, targetLane.children.length];
+      return moveEntity(boardData, this.currentPath, destinationPath);
+    });
+  }
+}

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -58,9 +58,9 @@ export const ItemCell = memo(
     const showItemMenu = useItemMenu({
       boardModifiers,
       item,
+      path,
       setEditState,
       stateManager,
-      path,
     });
 
     const onContextMenu: JSX.MouseEventHandler<HTMLDivElement> = useCallback(

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -235,7 +235,8 @@ const en = {
   'Add label': 'Add label',
   'Move to top': 'Move to top',
   'Move to bottom': 'Move to bottom',
-  'Move to list': 'Move to list',
+  'Move to column': 'Move to column',
+  'No other columns available': 'No other columns available',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Enter list title...',


### PR DESCRIPTION
Partially addresses https://github.com/mgmeyers/obsidian-kanban/issues/481.

This implementation focuses on moving cards between columns within the same board. Supporting moves between different boards would introduce additional complexity, so this change intentionally keeps the scope limited.

It also does not handle moving cards to the top or bottom of columns, since there are already separate commands that cover those cases.

This seemed like a reasonable starting point, with the possibility of expanding functionality later based on feedback and usage.