### PR TITLE
fix: clear stale kanbanFileModes, enable _loaded flag, fallback window in addView

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -210,8 +210,16 @@ export default class KanbanPlugin extends Plugin {
   }
 
   addView(view: KanbanView, data: string, shouldParseData: boolean) {
-    const win = view.getWindow();
-    const reg = this.windowRegistry.get(win);
+    let win = view.getWindow();
+    let reg = this.windowRegistry.get(win);
+
+    // If the view's current window isn't registered yet (e.g. containerEl not
+    // yet attached during a view-switch), fall back to the main window so the
+    // React portal can still mount instead of silently no-oping.
+    if (!reg) {
+      win = window;
+      reg = this.windowRegistry.get(win);
+    }
 
     if (!reg) return;
     if (!reg.viewMap.has(view.id)) {
@@ -734,6 +742,10 @@ export default class KanbanPlugin extends Plugin {
     const self = this;
 
     this.app.workspace.onLayoutReady(() => {
+      // Mark plugin fully loaded so the setViewState monkey-patch can redirect
+      // markdown opens to kanban view for files with the kanban frontmatter key.
+      self._loaded = true;
+
       this.register(
         around((app as any).commands, {
           executeCommand(next) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -329,6 +329,13 @@ export default class KanbanPlugin extends Plugin {
   }
 
   async setKanbanView(leaf: WorkspaceLeaf) {
+    // Clear any stale 'markdown' mode entry so setViewState monkey-patch and
+    // setViewData both see a clean kanban-mode state on re-entry.
+    const leafId = (leaf as any).id;
+    const filePath = (leaf.view as any).file?.path;
+    delete this.kanbanFileModes[leafId];
+    if (filePath) delete this.kanbanFileModes[filePath];
+
     await leaf.setViewState({
       type: kanbanViewType,
       state: leaf.view.getState(),


### PR DESCRIPTION
## Problem

When switching a kanban board to markdown view and then back to kanban view, the board renders as a black/blank screen (also reported in #662). Further investigation found two additional independent causes explaining why the black screen can still occur intermittently.

## Root Causes

### Cause 1 — Stale `kanbanFileModes` entry (reliable trigger, primary fix)

When switching to markdown view, `kanbanFileModes` is set to `'markdown'` for the leaf. Switching back via `setKanbanView` never cleared this entry. The monkey-patched `setViewState` checks `kanbanFileModes[...] !== 'markdown'` and finds the stale entry, so the kanban redirect never fires. The React portal fails to mount, producing the black screen.

### Cause 2 — `_loaded` never set to `true`

`_loaded` is declared as `false` and never set to `true` anywhere. The monkey-patched `setViewState` guards its markdown→kanban auto-redirect behind `self._loaded &&`, so that redirect was permanently dead. Kanban files opened from Recent Files, workspace restore, or internal links always opened as markdown instead of kanban, and could enter a broken state if other paths expected the redirect to have fired.

### Cause 3 — `addView` silently no-ops on window registry miss

`addView` calls `view.getWindow()` which resolves to `containerEl.win`. During a view-switch, `containerEl` may not yet be attached to the DOM, so the returned window has no entry in `windowRegistry`. The early `if (!reg) return` silently abandons the call — the React portal is never created, `contentEl` stays empty, and the board renders black.

## Fixes

- **`setKanbanView()`**: clear both the leaf-ID-keyed and file-path-keyed entries from `kanbanFileModes` on re-entry, so switching back to kanban always starts from a clean state.
- **`registerMonkeyPatches()` / `onLayoutReady`**: set `self._loaded = true`, activating the existing auto-redirect so kanban files open as kanban (not markdown) from Recent Files, workspace restore, and internal links.
- **`addView()`**: when `view.getWindow()` returns a window not in `windowRegistry`, fall back to `window` (main window) instead of returning early. The `onWindowMigrated` handler covers the pop-out window case later.

## Testing

- Kanban → markdown → kanban: board renders correctly without requiring note close/reopen
- Kanban files opened from Recent Files now open directly as kanban
- Intermittent black screen on first open resolved