### PR TITLE
Fix: date/time-trigger syntax leaking into filename on "New note from Card"

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -56,11 +56,28 @@ export function useItemMenu({
             .setTitle(t('New note from card'))
             .onClick(async () => {
               const prevTitle = item.data.titleRaw.split('\n')[0].trim();
+              const dateTrigger = stateManager.getSetting('date-trigger') as string;
+              const timeTrigger = stateManager.getSetting('time-trigger') as string;
+              const shouldLinkDates = stateManager.getSetting('link-date-to-daily-note');
+              const dateContentMatch = shouldLinkDates
+                ? '(?:\\[[^\\]]+\\]\\([^\\)]+\\)|\\[\\[[^\\]]+\\]\\])'
+                : '{[^}]+}';
+              const noteDateRegEx = new RegExp(
+                `(^|\\s)${escapeRegExpStr(dateTrigger)}${dateContentMatch}`,
+                'g'
+              );
+              const noteTimeRegEx = new RegExp(
+                `(^|\\s)${escapeRegExpStr(timeTrigger)}{[^}]+}`,
+                'g'
+              );
+
               const sanitizedTitle = prevTitle
                 .replace(embedRegEx, '$1')
                 .replace(wikilinkRegEx, '$1')
                 .replace(mdLinkRegEx, '$1')
                 .replace(tagRegEx, '$1')
+                .replace(noteDateRegEx, '$1')
+                .replace(noteTimeRegEx, '$1')
                 .replace(illegalCharsRegEx, ' ')
                 .trim()
                 .replace(condenceWhiteSpaceRE, ' ');
@@ -85,8 +102,14 @@ export function useItemMenu({
 
               await applyTemplate(stateManager, newNoteTemplatePath as string | undefined);
 
+              const matchTarget = prevTitle
+                .replace(noteDateRegEx, '$1')
+                .replace(noteTimeRegEx, '$1')
+                .trim()
+                .replace(condenceWhiteSpaceRE, ' ') || prevTitle;
+
               const newTitleRaw = item.data.titleRaw.replace(
-                prevTitle,
+                matchTarget,
                 stateManager.app.fileManager.generateMarkdownLink(newFile, stateManager.file.path)
               );
 


### PR DESCRIPTION
## Summary
Fixes a bug where dates/times leak raw `@{...}` syntax into filenames (and get silently deleted from the card) when using "New note from card."

Fixes #1137.

## The bug
The "New Note from Card" handler sanitized embeds, wikilinks, and tags when building the new note's filename, but never stripped date/time-trigger syntax (e.g. `@{2026-07-15}`). That raw syntax leaked directly into the generated filename and into the wikilink text inserted back into the card.

**Before (bug):**
<img width="611" height="411" alt="Screenshot 2026-07-15 at 23 27 15" src="https://github.com/user-attachments/assets/d1969ce5-2122-4981-9963-7bbce5797ab5" />

## The fix
- Stripped date/time tokens specifically for filename generation, using the same trigger-aware regex pattern already used by the existing "Remove date" menu action, so it respects custom `date-trigger`/`time-trigger` settings.
- Also preserves the date/time on the card itself: rather than replacing the entire raw title line (date included) with the new link, only the date/time-free portion of the title is now matched and replaced — so the date badge survives right next to the link instead of being silently deleted.
- Falls back to the original whole-line replacement if the title is *only* a date/time token, since there's no other text to anchor the link to.

**After (fix):**
<img width="296" height="283" alt="Screenshot 2026-07-15 at 23 32 17" src="https://github.com/user-attachments/assets/62f103cf-8226-4cfe-8d95-c7ab3ae38d8b" />


## Testing
- Verified with default `@` date/time triggers and custom ones (e.g. `@@@`, `$$`)
- Confirmed cards without dates are unaffected (filename and card text unchanged)
- Confirmed the date badge survives conversion and daily-note links still work when `link-date-to-daily-note` is enabled