### PR TITLE
Add board-level filter by inline field

### DIFF
--- a/docs/How do I/Filter a Kanban board.md
+++ b/docs/How do I/Filter a Kanban board.md
@@ -1,0 +1,10 @@
+
+You can filter a Kanban board by any inline field (e.g. `[assignee:: Alex]`) using the filter icon in the board header, next to the search icon.
+
+Click it to open two dropdowns: pick a field, then a value. The board narrows to lanes and cards matching that field/value, the same way search does. Click the filter icon again to collapse the picker into a small chip while keeping the filter applied; click the chip to reopen it, or the "x" to clear it.
+
+Only fields with a reasonably small number of distinct values are offered (12 or fewer) — a field like a due date is usually unique per card, so it isn't a meaningful filter axis and would just make the dropdown unusably long.
+
+If both a text search and a field filter are active, a card must match both to stay visible.
+
+The filter button can be hidden from the board header in Settings → Filter by..., the same way the search button can be hidden.

--- a/src/KanbanView.tsx
+++ b/src/KanbanView.tsx
@@ -428,6 +428,25 @@ export class KanbanView extends TextFileView implements HoverParent {
     }
 
     if (
+      stateManager.getSetting('show-field-filter') &&
+      !this.actionButtons['field-filter']
+    ) {
+      this.actionButtons['field-filter'] = this.addAction(
+        'lucide-filter',
+        t('Filter by...'),
+        () => {
+          this.emitter.emit('hotkey', { commandId: 'kanban:toggle-field-filter' });
+        }
+      );
+    } else if (
+      !stateManager.getSetting('show-field-filter') &&
+      this.actionButtons['field-filter']
+    ) {
+      this.actionButtons['field-filter'].remove();
+      delete this.actionButtons['field-filter'];
+    }
+
+    if (
       stateManager.getSetting('show-view-as-markdown') &&
       !this.actionButtons['show-view-as-markdown']
     ) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -80,6 +80,7 @@ export interface KanbanSettings {
   'show-archive-all'?: boolean;
   'show-board-settings'?: boolean;
   'show-checkboxes'?: boolean;
+  'show-field-filter'?: boolean;
   'show-relative-date'?: boolean;
   'show-search'?: boolean;
   'show-set-view'?: boolean;
@@ -128,6 +129,7 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'show-archive-all',
   'show-board-settings',
   'show-checkboxes',
+  'show-field-filter',
   'show-relative-date',
   'show-search',
   'show-set-view',
@@ -1486,6 +1488,46 @@ export class SettingsManager {
 
               this.applySettingsUpdate({
                 $unset: ['show-search'],
+              });
+            });
+        });
+    });
+
+    new Setting(contentEl).setName(t('Filter by...')).then((setting) => {
+      let toggleComponent: ToggleComponent;
+
+      setting
+        .addToggle((toggle) => {
+          toggleComponent = toggle;
+
+          const [value, globalValue] = this.getSetting('show-field-filter', local);
+
+          if (value !== undefined && value !== null) {
+            toggle.setValue(value as boolean);
+          } else if (globalValue !== undefined && globalValue !== null) {
+            toggle.setValue(globalValue as boolean);
+          } else {
+            // default
+            toggle.setValue(true);
+          }
+
+          toggle.onChange((newValue) => {
+            this.applySettingsUpdate({
+              'show-field-filter': {
+                $set: newValue,
+              },
+            });
+          });
+        })
+        .addExtraButton((b) => {
+          b.setIcon('lucide-rotate-ccw')
+            .setTooltip(t('Reset to default'))
+            .onClick(() => {
+              const [, globalValue] = this.getSetting('show-field-filter', local);
+              toggleComponent.setValue(!!globalValue);
+
+              this.applySettingsUpdate({
+                $unset: ['show-field-filter'],
               });
             });
         });

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -252,6 +252,7 @@ export class StateManager {
       'show-view-as-markdown':
         this.getSettingRaw('show-view-as-markdown', suppliedSettings) ?? true,
       'show-board-settings': this.getSettingRaw('show-board-settings', suppliedSettings) ?? true,
+      'show-field-filter': this.getSettingRaw('show-field-filter', suppliedSettings) ?? true,
       'show-search': this.getSettingRaw('show-search', suppliedSettings) ?? true,
       'show-set-view': this.getSettingRaw('show-set-view', suppliedSettings) ?? true,
       'tag-colors': this.getSettingRaw('tag-colors', suppliedSettings) ?? [],

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -195,7 +195,7 @@ export const Items = memo(function Items({ isStatic, items, shouldMarkItemsCompl
   return (
     <>
       {items.map((item, i) => {
-        return search?.query && !search.items.has(item) ? null : (
+        return (search?.query || search?.isFiltering) && !search.items.has(item) ? null : (
           <DraggableItem
             key={boardView + item.id}
             item={item}

--- a/src/components/Kanban.tsx
+++ b/src/components/Kanban.tsx
@@ -19,8 +19,20 @@ import { Lanes } from './Lane/Lane';
 import { LaneForm } from './Lane/LaneForm';
 import { TableView } from './Table/Table';
 import { KanbanContext, SearchContext } from './context';
-import { baseClassName, c, useSearchValue } from './helpers';
+import {
+  FieldFilterState,
+  baseClassName,
+  c,
+  collectInlineFieldOptions,
+  useFieldFilterMatches,
+  useSearchValue,
+} from './helpers';
 import { DataTypes } from './types';
+
+// Fields with more distinct values than this aren't offered in the filter dropdown (e.g. a
+// due-date field is usually near-unique per card, so it isn't a meaningful filter axis and
+// would just make the dropdown unusably long).
+const maxFilterableValues = 12;
 
 const boardScrollTiggers = [DataTypes.Item, DataTypes.Lane];
 const boardAccepts = [DataTypes.Lane];
@@ -55,6 +67,8 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string>('');
   const [isSearching, setIsSearching] = useState<boolean>(false);
+  const [fieldFilter, setFieldFilter] = useState<FieldFilterState | null>(null);
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState<boolean>(false);
 
   const [isLaneFormVisible, setIsLaneFormVisible] = useState<boolean>(
     boardData?.children.length === 0
@@ -105,6 +119,8 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
         } else {
           setIsSearching((val) => !val);
         }
+      } else if (data.commandId === 'kanban:toggle-field-filter') {
+        setIsFilterPanelOpen((val) => !val);
       }
     };
 
@@ -209,11 +225,41 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
     setDebouncedSearchQuery,
     setIsSearching
   );
+  const fieldFilterMatches = useFieldFilterMatches(boardData, fieldFilter);
+  const fieldFilterOptions = useMemo(() => collectInlineFieldOptions(boardData), [boardData]);
+  const filterableFieldKeys = useMemo(
+    () =>
+      Array.from(fieldFilterOptions.keys())
+        .filter((key) => fieldFilterOptions.get(key).size <= maxFilterableValues)
+        .sort((a, b) => a.localeCompare(b)),
+    [fieldFilterOptions]
+  );
+
+  // Merges the field filter into the existing text-search result set: with both active, a
+  // card must match the search query AND the field filter to stay visible. Reuses
+  // SearchContext's lanes/items sets so Lane/Item don't need a second, parallel hide path.
+  const combinedSearchValue = useMemo(() => {
+    if (!fieldFilter) return searchValue;
+
+    const lanes = searchValue.query
+      ? new Set([...searchValue.lanes].filter((lane) => fieldFilterMatches.lanes.has(lane)))
+      : fieldFilterMatches.lanes;
+    const items = searchValue.query
+      ? new Set([...searchValue.items].filter((item) => fieldFilterMatches.items.has(item)))
+      : fieldFilterMatches.items;
+
+    return {
+      ...searchValue,
+      lanes,
+      items,
+      isFiltering: true,
+    };
+  }, [searchValue, fieldFilterMatches, fieldFilter]);
 
   return (
     <DndScope id={view.id}>
       <KanbanContext.Provider value={kanbanContext}>
-        <SearchContext.Provider value={searchValue}>
+        <SearchContext.Provider value={combinedSearchValue}>
           <div
             ref={rootRef}
             className={classcat([
@@ -260,6 +306,82 @@ export const Kanban = ({ view, stateManager }: KanbanProps) => {
                   <Icon name="lucide-x" />
                 </a>
               </div>
+            )}
+            {isFilterPanelOpen ? (
+              <div className={c('search-wrapper')}>
+                <select
+                  className={c('field-filter-select')}
+                  value={fieldFilter?.key ?? ''}
+                  onChange={(e) => {
+                    const key = (e.target as HTMLSelectElement).value;
+                    if (!key) {
+                      setFieldFilter(null);
+                      return;
+                    }
+                    const values = fieldFilterOptions.get(key);
+                    const firstValue = values ? Array.from(values).sort()[0] : undefined;
+                    setFieldFilter(firstValue ? { key, value: firstValue } : null);
+                  }}
+                >
+                  <option value="">{t('Choose a field')}</option>
+                  {filterableFieldKeys.map((key) => (
+                    <option key={key} value={key}>
+                      {key}
+                    </option>
+                  ))}
+                </select>
+                {fieldFilter?.key && (
+                  <select
+                    className={c('field-filter-select')}
+                    value={fieldFilter.value}
+                    onChange={(e) => {
+                      setFieldFilter({
+                        key: fieldFilter.key,
+                        value: (e.target as HTMLSelectElement).value,
+                      });
+                    }}
+                  >
+                    {Array.from(fieldFilterOptions.get(fieldFilter.key) ?? [])
+                      .sort((a, b) => a.localeCompare(b))
+                      .map((value) => (
+                        <option key={value} value={value}>
+                          {value}
+                        </option>
+                      ))}
+                  </select>
+                )}
+                <a
+                  className={`${c('search-cancel-button')} clickable-icon`}
+                  onClick={() => {
+                    setFieldFilter(null);
+                    setIsFilterPanelOpen(false);
+                  }}
+                  aria-label={t('Clear filter')}
+                >
+                  <Icon name="lucide-x" />
+                </a>
+              </div>
+            ) : (
+              fieldFilter && (
+                <div className={c('search-wrapper')}>
+                  <div
+                    className={c('field-filter-label')}
+                    onClick={() => setIsFilterPanelOpen(true)}
+                  >
+                    <Icon name="lucide-filter" />
+                    <span>
+                      {fieldFilter.key}: {fieldFilter.value}
+                    </span>
+                  </div>
+                  <a
+                    className={`${c('search-cancel-button')} clickable-icon`}
+                    onClick={() => setFieldFilter(null)}
+                    aria-label={t('Clear filter')}
+                  >
+                    <Icon name="lucide-x" />
+                  </a>
+                </div>
+              )
             )}
             {boardView === 'table' ? (
               <TableView boardData={boardData} stateManager={stateManager} />

--- a/src/components/Lane/Lane.tsx
+++ b/src/components/Lane/Lane.tsx
@@ -166,7 +166,7 @@ function DraggableLaneRaw({
               toggleIsCollapsed={toggleIsCollapsed}
             />
 
-            {!search?.query && !isCollapsed && shouldPrepend && (
+            {!search?.query && !search?.isFiltering && !isCollapsed && shouldPrepend && (
               <ItemForm
                 addItems={addItems}
                 hideButton={isCompactPrepend}
@@ -206,7 +206,7 @@ function DraggableLaneRaw({
               </DroppableComponent>
             )}
 
-            {!search?.query && !isCollapsed && !shouldPrepend && (
+            {!search?.query && !search?.isFiltering && !isCollapsed && !shouldPrepend && (
               <ItemForm addItems={addItems} editState={editState} setEditState={setEditState} />
             )}
           </CollapsedDropArea>
@@ -235,7 +235,10 @@ function LanesRaw({ lanes, collapseDir }: LanesProps) {
         return (
           <DraggableLane
             collapseDir={collapseDir}
-            isCollapsed={(search?.query && !search.lanes.has(lane)) || !!collapseState[i]}
+            isCollapsed={
+              ((search?.query || search?.isFiltering) && !search.lanes.has(lane)) ||
+              !!collapseState[i]
+            }
             key={boardView + lane.id}
             lane={lane}
             laneIndex={i}

--- a/src/components/context.ts
+++ b/src/components/context.ts
@@ -20,6 +20,8 @@ export interface SearchContextProps {
   items: Set<Item>;
   lanes: Set<Lane>;
   search: (query: string, immediate?: boolean) => void;
+  /** True when a field filter (not just a text search) should hide non-matching lanes/items. */
+  isFiltering?: boolean;
 }
 
 export const SearchContext = createContext<SearchContextProps | null>(null);

--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -354,6 +354,66 @@ export function useOnMount(refs: RefObject<HTMLElement>[], cb: () => void, onUnm
   }, []);
 }
 
+export interface FieldFilterState {
+  key: string;
+  value: string;
+}
+
+/**
+ * Collects the distinct inline-field keys/values present on the board (e.g. `[porteur:: Gwénolé]`),
+ * for building the "Filter by" menu. Excludes Tasks-plugin emoji shorthand fields (due dates,
+ * priority, etc.) since those aren't meaningful as a board-wide filter axis.
+ */
+export function collectInlineFieldOptions(board: Board): Map<string, Set<string>> {
+  const options = new Map<string, Set<string>>();
+
+  board.children.forEach((lane) => {
+    lane.children.forEach((item) => {
+      item.data.metadata.inlineMetadata?.forEach((field) => {
+        if (field.wrapping === 'emoji-shorthand') return;
+        if (!field.key || !field.value) return;
+
+        if (!options.has(field.key)) {
+          options.set(field.key, new Set());
+        }
+
+        options.get(field.key).add(field.value);
+      });
+    });
+  });
+
+  return options;
+}
+
+export function useFieldFilterMatches(
+  board: Board,
+  filter: FieldFilterState | null
+): { lanes: Set<Lane>; items: Set<Item> } {
+  return useMemo(() => {
+    const lanes = new Set<Lane>();
+    const items = new Set<Item>();
+
+    if (filter) {
+      board.children.forEach((lane) => {
+        let laneMatched = false;
+        lane.children.forEach((item) => {
+          const isMatch = item.data.metadata.inlineMetadata?.some(
+            (field) => field.key === filter.key && field.value === filter.value
+          );
+
+          if (isMatch) {
+            laneMatched = true;
+            items.add(item);
+          }
+        });
+        if (laneMatched) lanes.add(lane);
+      });
+    }
+
+    return { lanes, items };
+  }, [board, filter?.key, filter?.value]);
+}
+
 export function useSearchValue(
   board: Board,
   query: string,

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -22,6 +22,9 @@ const en = {
   'Open as markdown': 'Open as markdown',
   'Open board settings': 'Open board settings',
   'Archive completed cards': 'Archive completed cards',
+  'Filter by...': 'Filter by...',
+  'Clear filter': 'Clear filter',
+  'Choose a field': 'Choose a field',
   'Something went wrong': 'Something went wrong',
   'You may wish to open as markdown and inspect or edit the file.':
     'You may wish to open as markdown and inspect or edit the file.',

--- a/src/styles.less
+++ b/src/styles.less
@@ -261,6 +261,21 @@ button.kanban-plugin__search-cancel-button .kanban-plugin__icon {
   display: flex;
 }
 
+.kanban-plugin__field-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: var(--font-ui-small, 13px);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.kanban-plugin__field-filter-select {
+  margin-inline-end: 5px;
+  max-width: 160px;
+}
+
 .kanban-plugin__icon {
   display: inline-block;
   line-height: 1;


### PR DESCRIPTION
## Summary

Adds a dedicated **filter** icon next to **Search** in the board header. Clicking it opens two inline dropdowns — field, then value — built from the board's existing inline fields (e.g. `[assignee:: Alex]`), narrowing the board to matching lanes/cards the same way search already does. A second click collapses the picker into a small chip while the filter stays applied; the "x" clears it.

- Fields with more than 12 distinct values are excluded from the field dropdown (e.g. a due date is usually near-unique per card, so it isn't a meaningful filter axis and would make the dropdown unusably long).
- An active text search and field filter compose with AND semantics, reusing the existing `SearchContext` lanes/items sets rather than adding a second hide path.
- The header button has its own `show-field-filter` setting, following the existing pattern for the other header buttons (Search, Board view, etc).
- Added a docs page (`docs/How do I/Filter a Kanban board.md`) mirroring the existing "Search a Kanban board" page. No screenshot included — happy to add one if useful, just didn't want to source it from a personal vault.

## Implementation note

I first tried a cascading `Menu`/`MenuItem` submenu (field list → value list), matching the existing "Board view" button's pattern. `MenuItem`'s `onClick` event didn't reliably carry usable position data for positioning the second menu in my testing, so I fell back to inline native `<select>` elements in the same DOM slot as the search bar — this sidesteps `Menu` positioning entirely and keeps the UI consistent with how search already works.

## Disclosure

This PR was built through an interactive [Claude Code](https://claude.com/claude-code) session (Anthropic), then reviewed and tested by me end-to-end in my own vault before opening this PR. I'm flagging this explicitly per the note in `MAINTAINERS.md` about LLM-assisted contributions — wanted to be upfront rather than silent about it, and am glad to adjust anything that doesn't fit the codebase's conventions.

## Test plan

- [x] Typechecked (`tsc --noemit`) — no new errors vs. `main`
- [x] Manually tested in a real vault: filtering by field/value narrows lanes and cards correctly, clearing restores the board, toggling the panel open/closed preserves the active filter, combining with text search applies AND semantics
- [ ] No automated tests added (repo doesn't appear to have a test suite for UI behavior)