### PR TITLE
fix: support Outline navigation for Kanban lanes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -336,6 +336,39 @@ export default class KanbanPlugin extends Plugin {
     } as ViewState);
   }
 
+  navigateKanbanSubpath(view: KanbanView, subpath: string): Promise<void> {
+    let heading = subpath.replace(/^#/, '');
+
+    try {
+      heading = decodeURIComponent(heading);
+    } catch {
+      // Obsidian can pass an unescaped heading, which is already usable as-is.
+    }
+
+    const normalizeHeading = (value: string) => value.normalize('NFKC').trim().replace(/\s+/g, ' ');
+    const targetHeading = normalizeHeading(heading);
+    const laneTitles = Array.from(
+      view.contentEl.querySelectorAll<HTMLElement>('.kanban-plugin__lane-title-text')
+    );
+    const laneTitle = laneTitles.find(
+      (element) => normalizeHeading(element.textContent || '') === targetHeading
+    );
+    const lane = laneTitle?.closest<HTMLElement>('.kanban-plugin__lane-wrapper');
+
+    view.getWindow().requestAnimationFrame(() => {
+      if (lane) {
+        lane.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+      } else {
+        const firstLane = view.contentEl.querySelector<HTMLElement>(
+          '.kanban-plugin__lane-wrapper'
+        );
+        firstLane?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+      }
+    });
+
+    return Promise.resolve();
+  }
+
   async newKanban(folder?: TFolder) {
     const targetFolder = folder
       ? folder
@@ -779,6 +812,33 @@ export default class KanbanPlugin extends Plugin {
 
         setViewState(next) {
           return function (state: ViewState, ...rest: any[]) {
+            const currentView = this.view;
+            const subpath = (state as ViewState & { eState?: { subpath?: string } }).eState
+              ?.subpath;
+            const line = rest.find(
+              (value) => typeof value?.line === 'number'
+            )?.line as number | undefined;
+
+            if (
+              currentView instanceof KanbanView &&
+              state.type === 'markdown' &&
+              state.state?.file === currentView.file?.path
+            ) {
+              if (subpath?.startsWith('#')) {
+                return self.navigateKanbanSubpath(currentView, subpath);
+              }
+
+              if (line !== undefined) {
+                const heading = self.app.metadataCache
+                  .getFileCache(currentView.file)
+                  ?.headings?.find((entry) => entry.position.start.line === line)?.heading;
+
+                if (heading) {
+                  return self.navigateKanbanSubpath(currentView, `#${heading}`);
+                }
+              }
+            }
+
             if (
               // Don't force kanban mode during shutdown
               self._loaded &&


### PR DESCRIPTION
## Summary

Fix Outline navigation for open Kanban boards without replacing the active `KanbanView`.

When an Outline heading is selected, Obsidian requests a Markdown view for the same file and supplies either a heading subpath or a line number. Letting that request continue unloads the Kanban view and unregisters its portal, leaving the board blank until the tab is reopened.

This change intercepts same-file Outline navigation while the current view is a `KanbanView` and scrolls the matching lane into view instead.

## Changes

- Handle heading subpaths passed through `ViewState.eState.subpath`.
- Resolve Outline line-number navigation through `metadataCache` headings.
- Normalize URL-encoded, Unicode, and whitespace variants before matching lane titles.
- Keep the existing Kanban view and portal mounted while scrolling to the requested lane.

## Validation

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- Clicked all six Outline lane headings on a live board and confirmed the same leaf and `KanbanView` remained active.
- Confirmed the portal remained registered, the board DOM remained populated, and no console errors were emitted.
- Tested encoded and unescaped heading subpaths, including Chinese text and whitespace normalization.

Fixes #978

Related: #191, #824
