### PR TITLE
fix: reject whitespace-only card and list titles

### DIFF
--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -26,6 +26,8 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
   });
 
   const createItem = (title: string) => {
+    if (!title.trim()) return;
+
     addItems([stateManager.getNewItem(title, ' ')]);
     const cm = editorRef.current;
     if (cm) {

--- a/src/components/Lane/LaneForm.tsx
+++ b/src/components/Lane/LaneForm.tsx
@@ -30,6 +30,8 @@ export function LaneForm({ onNewLane, closeLaneForm }: LaneFormProps) {
 
   const createLane = useCallback(
     (cm: EditorView, title: string) => {
+      if (!title.trim()) return;
+
       boardModifiers.addLane({
         ...LaneTemplate,
         id: generateInstanceId(),


### PR DESCRIPTION
## Summary

Prevent the new-card and new-list forms from creating entities whose titles contain only whitespace.

Both forms currently pass their editor contents directly to the board creation logic. The parser trims the input, but it still produces an item or lane with an empty title. This leaves blank cards or lists in the board Markdown.

## Changes

- Ignore whitespace-only submissions in the new-card form.
- Ignore whitespace-only submissions in the new-list form.
- Keep the editor content and list completion toggle unchanged after an invalid submission.
- Keep validation at the UI form boundary so existing blank placeholder cards created by actions such as "Insert card before/after" continue to work.

## Validation

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
- Reproduced the original behavior with the guards removed.
- Confirmed spaces, tabs, newlines, and mixed whitespace no longer create cards or lists.
- Confirmed invalid submissions preserve the editor content and list completion toggle.
- Confirmed valid titles, including titles with surrounding whitespace, are still created normally.
- Confirmed the underlying forced-edit blank placeholder item path remains available.

Fixes #1203
