### PR TITLE
fix: prevent link drop navigation

### DIFF
--- a/src/dnd/managers/DragManager.ts
+++ b/src/dnd/managers/DragManager.ts
@@ -479,8 +479,9 @@ export function createHTMLDndHandlers(stateManager: StateManager) {
   const dndManager = useContext(DndManagerContext);
   const onDragOver = useCallback(
     (e: DragEvent) => {
+      e.preventDefault();
+
       if (dndManager.dragManager.isHTMLDragging) {
-        e.preventDefault();
         dndManager.dragManager.dragMoveHTML(e);
       } else {
         dndManager.dragManager.dragStartHTML(e, stateManager.getAView().id);
@@ -495,6 +496,8 @@ export function createHTMLDndHandlers(stateManager: StateManager) {
 
   const onDrop = useCallback(
     async (e: DragEvent) => {
+      e.preventDefault();
+
       dndManager.dragManager.dragEndHTML(
         e,
         stateManager.getAView().id,


### PR DESCRIPTION
## Summary

- prevent the native default action from the first external `dragover`
- prevent URL drop navigation before asynchronously parsing and inserting the dropped content
- preserve event propagation and the existing URL, file, folder, and internal-link handling

## Verification

- reproduced the issue with Obsidian Web Viewer enabled: dropping a browser URL created the Kanban content and also opened the URL
- confirmed the fixed `dragover` and `drop` events are default-prevented while still bubbling
- confirmed browser/Web Viewer URL drops still create the expected card without opening the page
- confirmed Obsidian file, folder, and internal-link drops still work
- confirmed Finder file drops still work
- ran `yarn typecheck`, `yarn lint`, `yarn build`, and `git diff --check`

Fixes #1160
